### PR TITLE
Corrections in gff code

### DIFF
--- a/src/neverwinter/gff.nim
+++ b/src/neverwinter/gff.nim
@@ -160,6 +160,7 @@ proc typeDescToKind*[T : GffFieldType](ofType: typedesc[T]): GffFieldKind {.inli
   elif ofType is GffDouble: result = GffFieldKind.Double
   elif ofType is GffCExoString: result = GffFieldKind.CExoString
   elif ofType is GffResRef: result = GffFieldKind.ResRef
+  elif ofType is GFFVoid: result = GffFieldKind.Void
   elif ofType is GffCExoLocString: result = GffFieldKind.CExoLocString
   elif ofType is GffList: result = GffFieldKind.List
   elif ofType is GffStruct: result = GffFieldKind.Struct

--- a/src/neverwinter/gff.nim
+++ b/src/neverwinter/gff.nim
@@ -223,7 +223,7 @@ proc getValue*[T: GffFieldType](self: GffField, t: typedesc[T]): T =
   elif T is GffShort: cast[int16](self.dataOrOffset)
   elif T is GffDword: cast[uint32](self.dataOrOffset)
   elif T is GffInt: cast[int32](self.dataOrOffset)
-  elif T is GffFloat: cast[float](self.dataOrOffset)
+  elif T is GffFloat: cast[float32](self.dataOrOffset)
 
   elif T is GffDword64: self.gffDword64
   elif T is GffInt64: self.gffInt64

--- a/src/neverwinter/gffjson.nim
+++ b/src/neverwinter/gffjson.nim
@@ -92,6 +92,9 @@ proc gffStructFromJson*(j: JSONNode, result: GffStruct) =
     of "resref":
       expect(v["value"].kind == JString, $v)
       result[k, GffResRef] = v["value"].str.GffResRef
+    of "void":
+      expect(v["value"].kind == JString, $v)
+      result[k, GffVoid] = v["value"].str.GffVoid
 
     of "struct":
       expect(v["value"].kind == JObject, $v)


### PR DESCRIPTION
The gff and gffJson modules were missing the void type several case statements

The gff.getValue had float vs float 32 which was not correctly converting negative -0.0 float values - instead placing 'nan' in the JSON output
