### PR TITLE
"Bad Strref" issue, explicitly initialize strRef

### DIFF
--- a/src/neverwinter/gff.nim
+++ b/src/neverwinter/gff.nim
@@ -261,6 +261,7 @@ proc newGffList*(): GffList = newSeq[GffStruct]()
 proc newCExoLocString*(): GffCExoLocString =
   new(result)
   result.entries = newTable[int, string]()
+  result.strRef = -1
 
 proc initGffStruct(self: GffStruct, id: int32 = -1) =
   self.fields = newTable[string, GffField]()


### PR DESCRIPTION
This is the fix you gave me in discord for the `Bad Strref` issue when creating gff files from json with no strref set.

I tried it on my module and it worked fine after this change.