### PR TITLE
Fix ProgressBar crash

### DIFF
--- a/private/progressbar.nim
+++ b/private/progressbar.nim
@@ -45,7 +45,7 @@ proc write*(io: File, self: ProgressBar) =
     let tWidth = terminalWidth() - 1
     var t = $self
     let tmax = min(tWidth, t.high)
-    t = t[0..tmax] & repeat(" ", max(0, tWidth - tmax - 1))
+    t = t[0..tmax] & repeat(" ", max(0, tWidth - tmax))
     io.write "\r" & t
     if defined(windows): io.cursorUp()
     io.flushFile()


### PR DESCRIPTION
This resolve an error (discovered on windows, unknown linux impact) introduced by 58cf909, causing at least nwn_key_unpack and potentially others to incorrectly display and error-out due to `repeat` not padding as far as necessary, causing `cursorUp` to act unexpectedly, writing to the terminal bottom-to-top briefly until it crashes.