### PR TITLE
Swap depreciated csize for csize_t (Fixes RangeError)

### DIFF
--- a/neverwinter/private/zstd/binding.nim
+++ b/neverwinter/private/zstd/binding.nim
@@ -51,21 +51,21 @@ const sourceRoot = currentSourcePath().splitPath.head
 proc ZSTD_versionString*(): cstring {.importc.}
 proc ZSTD_versionNumber*(): cuint {.importc.}
 
-proc ZSTD_isError*(srcSize: csize): csize {.importc.}
-proc ZSTD_getErrorName*(srcSize: csize): cstring {.importc.}
+proc ZSTD_isError*(srcsize_t: csize_t): csize_t {.importc.}
+proc ZSTD_getErrorName*(srcsize_t: csize_t): cstring {.importc.}
 
-proc ZSTD_compressBound*(srcSize: csize): csize {.importc.}
+proc ZSTD_compressBound*(srcsize_t: csize_t): csize_t {.importc.}
 
 proc ZSTD_compress*(
-  dst: pointer, dstCapacity: csize,
-  src: pointer, srcSize: csize,
-  compressionLevel: cint): csize {.importc: "ZSTD_compress".}
+  dst: pointer, dstCapacity: csize_t,
+  src: pointer, srcsize_t: csize_t,
+  compressionLevel: cint): csize_t {.importc: "ZSTD_compress".}
 
-proc ZSTD_getFrameContentSize*(src: pointer, srcSize: csize): culonglong {.importc.}
+proc ZSTD_getFrameContentSize*(src: pointer, srcsize_t: csize_t): culonglong {.importc.}
 
 proc ZSTD_decompress*(
-  dst: pointer, dstSize: csize,
-  src: pointer, compressedSize: csize): csize {.importc.}
+  dst: pointer, dstSize: csize_t,
+  src: pointer, compressedSize: csize_t): csize_t {.importc.}
 
 type ZSTD_CCtx* = distinct pointer
 type ZSTD_DCtx* = distinct pointer
@@ -76,11 +76,11 @@ proc ZSTD_freeDCtx*(ctx: ZSTD_DCtx): cuint {.importc.}
 
 proc ZSTD_compressCCtx*(
   ctx: ZSTD_CCtx,
-  dst: pointer, dstCapacity: csize,
-  src: pointer, srcSize: csize,
-  compressionLevel: cint): csize {.importc.}
+  dst: pointer, dstCapacity: csize_t,
+  src: pointer, srcsize_t: csize_t,
+  compressionLevel: cint): csize_t {.importc.}
 
 proc ZSTD_decompressDCtx*(
   ctx: ZSTD_DCtx,
-  dst: pointer, dstCapacity: csize,
-  src: pointer, srcSize: csize): csize {.importc.}
+  dst: pointer, dstCapacity: csize_t,
+  src: pointer, srcsize_t: csize_t): csize_t {.importc.}

--- a/neverwinter/zstd.nim
+++ b/neverwinter/zstd.nim
@@ -17,40 +17,40 @@ proc newDecompressionContext*(): DecompressionContext =
   result.ctx = ZSTD_createDCtx()
 
 proc getCompressBound*(inputlen: int): int =
-  ZSTD_compressBound(inputlen)
+  ZSTD_compressBound(inputlen.csize_t).int
 
 proc getFrameContentSize*(input: string): int =
-  result = int ZSTD_getFrameContentSize(unsafeAddr(input[0]), input.len)
+  result = int ZSTD_getFrameContentSize(unsafeAddr(input[0]), input.len.csize_t)
   if result == -1: raise newException(ValueError, "ContentSize Unknown")
   if result == -2: raise newException(ValueError, "ContentSize Error")
 
 proc compress*(input: string, level: int = 3, ctx: CompressionContext = nil): string =
-  let strlen = ZSTD_compressBound(input.len)
+  let strlen = ZSTD_compressBound(input.len.csize_t)
   if ZSTD_isError(strlen) > 0:
     raise newException(ValueError, $ZSTD_getErrorName(strlen))
   result = newString(strlen)
 
   let err =
     if not isNil(ctx):
-      ZSTD_compressCCtx(ctx.ctx, addr(result[0]), strlen, unsafeAddr(input[0]), input.len, level.cint)
+      ZSTD_compressCCtx(ctx.ctx, addr(result[0]), strlen, unsafeAddr(input[0]), input.len.csize_t, level.cint)
     else:
-      ZSTD_compress(addr(result[0]), strlen, unsafeAddr(input[0]), input.len, level.cint)
+      ZSTD_compress(addr(result[0]), strlen, unsafeAddr(input[0]), input.len.csize_t, level.cint)
 
   if ZSTD_isError(err) > 0:
     raise newException(ValueError, $ZSTD_getErrorName(err))
   result.setLen(err)
 
 proc decompress*(input: string, ctx: DecompressionContext = nil): string =
-  let strlen = ZSTD_getFrameContentSize(unsafeAddr(input[0]), input.len).csize
+  let strlen = ZSTD_getFrameContentSize(unsafeAddr(input[0]), input.len.csize_t).csize_t
   if ZSTD_isError(strlen) > 0:
     raise newException(ValueError, $ZSTD_getErrorName(strlen))
   result = newString(strlen)
 
   let err =
     if not isNil(ctx):
-      ZSTD_decompressDCtx(ctx.ctx, addr(result[0]), strlen, unsafeAddr(input[0]), input.len)
+      ZSTD_decompressDCtx(ctx.ctx, addr(result[0]), strlen, unsafeAddr(input[0]), input.len.csize_t)
     else:
-      ZSTD_decompress(addr(result[0]), strlen, unsafeAddr(input[0]), input.len)
+      ZSTD_decompress(addr(result[0]), strlen, unsafeAddr(input[0]), input.len.csize_t)
 
   if ZSTD_isError(err) > 0:
     raise newException(ValueError, $ZSTD_getErrorName(err))


### PR DESCRIPTION
Corrects the "Value out of range" nonsense error when decompressing. Simply swapped every csize to csize_t then kept casting things to csize_t until it worked, so may well be an incorrect method of doing so but it worked.