### PR TITLE
neverwinter.nimble: import os instead of ospaths

### DIFF
--- a/neverwinter.nimble
+++ b/neverwinter.nimble
@@ -1,4 +1,4 @@
-import sequtils, ospaths, strutils
+import sequtils, os, strutils
 
 version       = "1.3.1"
 author        = "Bernhard Stöckner <niv@nwnx.io>"


### PR DESCRIPTION
running nimble with `import os` gives me `Warning: import os.nim instead; ospaths is deprecated [Deprecated]` (at least with nim 1.2.6)