### PR TITLE
GitHub Workflow to create release with binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,223 @@
+name: Create a release
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  NIMVER: "1.2.6"
+
+jobs:
+  build-linux-win:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        bintype: [linux, win-i386, win-amd64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache nim, nimble
+        uses: actions/cache@v2
+        id: cache
+        with:
+          key: build-${{ matrix.bintype }}-nim-${{ env.NIMVER }}
+          path: |
+            nim
+            ~/.nimble
+
+      - name: Install mingw
+        if: matrix.bintype != 'linux'
+        run: sudo apt-get install -y --no-install-recommends mingw-w64
+
+      - name: Download nim, add to PATH
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir nim
+          cd nim
+          wget https://nim-lang.org/download/nim-$NIMVER-linux_x64.tar.xz
+          tar xf nim-$NIMVER-linux_x64.tar.xz
+          echo "::set-env name=PATH::$PWD/nim-$NIMVER/bin:$PATH"
+
+      - name: Install nimble packages
+        run: nimble install -y
+
+      - name: Compile for Linux
+        if: matrix.bintype == 'linux'
+        run: nimble build -d:release
+
+      - name: Upload Linux artifact
+        if: matrix.bintype == 'linux'
+        uses: actions/upload-artifact@v2
+        with:
+          name: neverwinter.linux.amd64
+          path: bin/*
+
+      - name: Compile for Windows i386
+        if: matrix.bintype == 'win-i386'
+        # on Ubuntu the binary has no .exe extension for some reason
+        run: |
+          nimble build -d:release -d:mingw --cpu:i386
+          for f in bin/*; do mv "$f" "$f.exe"; done
+
+      - name: Upload Windows i386 artifact
+        if: matrix.bintype == 'win-i386'
+        uses: actions/upload-artifact@v2
+        with:
+          name: neverwinter.windows.i386
+          path: bin/*
+
+      - name: Compile for Windows amd64
+        if: matrix.bintype == 'win-amd64'
+        run: |
+          nimble build -d:release -d:mingw --cpu:amd64
+          for f in bin/*; do mv "$f" "$f.exe"; done
+
+      - name: Upload Windows amd64 artifact
+        if: matrix.bintype == 'win-amd64'
+        uses: actions/upload-artifact@v2
+        with:
+          name: neverwinter.windows.amd64
+          path: bin/*
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache nim, nimble
+        uses: actions/cache@v2
+        id: cache
+        with:
+          key: build-macos-${{ env.NIMVER }}
+          path: |
+            nim
+            ~/.nimble
+
+      - name: Download and build nim, add to PATH
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir nim
+          cd nim
+          wget https://nim-lang.org/download/nim-$NIMVER.tar.xz
+          tar xf nim-$NIMVER.tar.xz
+          cd nim-$NIMVER
+          sh build.sh
+          bin/nim c koch
+          ./koch boot -d:release
+          ./koch tools
+          echo "::set-env name=PATH::$PWD/bin:$PATH"
+
+      - name: Install nimble packages
+        run: nimble install -y
+
+      - name: Compile for macOS
+        run: nimble build -d:release
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: neverwinter.macos.amd64
+          path: bin/*
+
+  release:
+    needs: [build-linux-win, build-macos]
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: neverwinter.linux.amd64
+          path: bin-linux
+
+      - name: Pack Linux artifact
+        # the executable flag is removed on artifact upload
+        working-directory: bin-linux
+        run: |
+          chmod +x *
+          zip neverwinter.linux.amd64.zip *
+
+      - name: Download Windows i386 artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: neverwinter.windows.i386
+          path: bin-windows-i386
+
+      - name: Pack Windows i386 artifact
+        working-directory: bin-windows-i386
+        run: zip neverwinter.windows.i386.zip *
+
+      - name: Download Windows amd64 artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: neverwinter.windows.amd64
+          path: bin-windows-amd64
+
+      - name: Pack Windows amd64 artifact
+        working-directory: bin-windows-amd64
+        run: zip neverwinter.windows.amd64.zip *
+
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: neverwinter.macos.amd64
+          path: bin-macos
+
+      - name: Pack macOS artifact
+        working-directory: bin-macos
+        run: |
+          chmod +x *
+          zip neverwinter.macosx.amd64.zip *
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Linux release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin-linux/neverwinter.linux.amd64.zip
+          asset_name: neverwinter.linux.amd64.zip
+          asset_content_type: application/zip
+
+      - name: Upload Windows i386 release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin-windows-i386/neverwinter.windows.i386.zip
+          asset_name: neverwinter.windows.i386.zip
+          asset_content_type: application/zip
+
+      - name: Upload Windows amd64 release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin-windows-amd64/neverwinter.windows.amd64.zip
+          asset_name: neverwinter.windows.amd64.zip
+          asset_content_type: application/zip
+
+      - name: Upload macOS release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin-macos/neverwinter.macosx.amd64.zip
+          asset_name: neverwinter.macosx.amd64.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
This will build binaries and create a release on push of any tag. I followed your naming conventions. I tested it in my fork and it looked good. 4 builds will run in parallel (linux, win i386, win amd64. mac). In my tests I never got a cache hit, so it will take up to 15 minutes to build. Not sure what the issue with the cache is.

NIMVER is set to 1.2.6. If changed, a different file will be downloaded for the nim install. It should work but I did not test other versions.