### PR TITLE
Update to nim 1.4.0

### DIFF
--- a/neverwinter.nimble
+++ b/neverwinter.nimble
@@ -5,7 +5,7 @@ author        = "Bernhard Stöckner <niv@nwnx.io>"
 description   = "Neverwinter Nights 1: Enhanced Edition data accessor library and utilities"
 license       = "MIT"
 
-requires "nim >= 1.4.0"
+requires "nim >= 1.0.8"
 
 installDirs = @["neverwinter"]
 

--- a/neverwinter.nimble
+++ b/neverwinter.nimble
@@ -5,7 +5,7 @@ author        = "Bernhard Stöckner <niv@nwnx.io>"
 description   = "Neverwinter Nights 1: Enhanced Edition data accessor library and utilities"
 license       = "MIT"
 
-requires "nim >= 1.0.8"
+requires "nim >= 1.4.0"
 
 installDirs = @["neverwinter"]
 

--- a/neverwinter/resdir.nim
+++ b/neverwinter/resdir.nim
@@ -4,7 +4,7 @@
 
 import streams, strutils, os, logging
 
-import resman, util
+import resman
 
 type
   ResDir* = ref object of ResContainer

--- a/neverwinter/resfile.nim
+++ b/neverwinter/resfile.nim
@@ -3,7 +3,7 @@
 
 import streams, strutils, os
 
-import resman, util
+import resman
 
 type
   ResFile* = ref object of ResContainer

--- a/neverwinter/resmemfile.nim
+++ b/neverwinter/resmemfile.nim
@@ -1,6 +1,6 @@
 import streams, strutils, os, times
 
-import resman, util
+import resman
 
 type
   ResMemFile* = ref object of ResContainer

--- a/neverwinter/twoda.nim
+++ b/neverwinter/twoda.nim
@@ -29,7 +29,7 @@ proc `[]`*(self: TwoDA, row: Natural): Option[Row] =
   ## Looks up a row value on this 2da.
   ## Will return a none if out of bounds.
   if row < self.rows.len: some self.rows[row]
-  else: none Row # raise newException(IndexError, "Out of bounds")
+  else: none Row # raise newException(IndexDefect, "Out of bounds")
 
 proc `[]=`*(self: TwoDA, row: Natural, data: Row) =
   ## Assign a row. To clear row data, assign a empty seq. Adding a row
@@ -64,13 +64,13 @@ proc `[]`*(self: TwoDA, row: Natural, column: string, default: string): string =
 
 proc `[]=`*(self: TwoDA, row: Natural, column: string, value: Cell) =
   ## Sets a single cell value.
-  ## Will raise IndexError if either row or column don't exist.
+  ## Will raise IndexDefect if either row or column don't exist.
   if row >= self.rows.len:
-    raise newException(IndexError, "Row out of bounds")
+    raise newException(IndexDefect, "Row out of bounds")
 
   let colId = self.headersForLookup.find(column.toLowerAscii)
   if colId == -1:
-    raise newException(IndexError, "Column not found: " & column)
+    raise newException(IndexDefect, "Column not found: " & column)
 
   self.rows[row][colId] = value
 

--- a/neverwinter/twoda.nim
+++ b/neverwinter/twoda.nim
@@ -66,11 +66,17 @@ proc `[]=`*(self: TwoDA, row: Natural, column: string, value: Cell) =
   ## Sets a single cell value.
   ## Will raise IndexDefect if either row or column don't exist.
   if row >= self.rows.len:
-    raise newException(IndexDefect, "Row out of bounds")
+    when (NimMajor, NimMinor, NimPatch) >= (1, 4, 0):
+      raise newException(IndexDefect, "Row out of bounds")
+    else:
+      raise newException(IndexError, "Row out of bounds")
 
   let colId = self.headersForLookup.find(column.toLowerAscii)
   if colId == -1:
-    raise newException(IndexDefect, "Column not found: " & column)
+    when (NimMajor, NimMinor, NimPatch) >= (1, 4, 0):
+      raise newException(IndexDefect, "Column not found: " & column)
+    else:
+      raise newException(IndexError, "Column not found: " & column)
 
   self.rows[row][colId] = value
 

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,2 +1,3 @@
 --path:"."
 --path:"private"
+--warning[LockLevel]:off

--- a/nwn_erf_tlkify.nim
+++ b/nwn_erf_tlkify.nim
@@ -1,9 +1,9 @@
 import shared
 
-import critbits, os, osproc, tables, options, sets, sequtils, strutils, logging
+import critbits, os, tables, options, sets, sequtils, strutils, logging
 
 import neverwinter/gff, neverwinter/erf, neverwinter/resman,
-  neverwinter/resref, neverwinter/tlk, neverwinter/twoda
+  neverwinter/resref, neverwinter/tlk
 
 let Args = DOC """
 This utility reads a ERF (mod, hak), extracting all strings in

--- a/nwn_net.nim
+++ b/nwn_net.nim
@@ -1,6 +1,11 @@
 import arpie, net, strutils, sequtils, os, jser, docopt, times
-import net, asyncnet, asyncdispatch, netutil, nativesockets
+import net, asyncdispatch, netutil, nativesockets
 import shared
+
+when (NimMajor, NimMinor, NimPatch) >= (1, 4, 0):
+  import asyncnet
+else:
+  import asyncnetudp
 
 let args = DOC """
 Generic NWN1 game server query tool.

--- a/nwn_net.nim
+++ b/nwn_net.nim
@@ -1,5 +1,5 @@
 import arpie, net, strutils, sequtils, os, jser, docopt, times
-import net, asyncnetudp, asyncdispatch, netutil, nativesockets
+import net, asyncnet, asyncdispatch, netutil, nativesockets
 import shared
 
 let args = DOC """

--- a/private/docopt.nim
+++ b/private/docopt.nim
@@ -174,9 +174,9 @@ proc val(v: seq[string]): Value = Value(kind: vkList, list_v: v)
 ### EMBEDDED: docopt
 
 type
-    DocoptLanguageError* = object of Exception
+    DocoptLanguageError* = object of Defect
         ## Error in construction of usage-message by developer.
-    DocoptExit* = object of Exception
+    DocoptExit* = object of CatchableError
         ## Exit in case user invoked program with incorrect arguments.
         usage*: string
 

--- a/private/jser.nim
+++ b/private/jser.nim
@@ -78,8 +78,6 @@ const
     SerializerFlags.SkipNil
   }
 
-import sequtils
-
 type
   IntType =
     uint | int | int8 | int16 | int32 | int64 |

--- a/private/jser.nim
+++ b/private/jser.nim
@@ -41,7 +41,7 @@ import json
 export json
 
 type
-  DeserializeError* = object of Exception ## \
+  DeserializeError* = object of CatchableError ## \
   ## Raised when something prevents json from being deserialized into a tuple.
   ## Your tuple might be in a undefined state at that point.
 

--- a/private/netutil.nim
+++ b/private/netutil.nim
@@ -1,4 +1,4 @@
-import asyncnetudp, arpie, logging, net, asyncdispatch, times, json,
+import asyncnet, arpie, logging, net, asyncdispatch, times, json,
   nativesockets
 
 type AskResult* = tuple
@@ -10,8 +10,10 @@ proc ask*(socket: AsyncSocket, host: string, port: Port,
   debug "Asking ", host, ":", port, " for ", data
 
   let tstart = epochTime() * 1000
-  if -1 == socket.sendTo(host, port, data):
-    raise newException(IOError, "Send failed")
+  try:
+    socket.sendTo(host, port, data):
+  except:
+    raise newException(IOError, "Send failed: " & getCurrentExceptionMsg())
 
   let fut = socket.recvFrom(65_000)
   let waitable = withTimeout(fut, timeout)

--- a/private/shared.nim
+++ b/private/shared.nim
@@ -1,6 +1,8 @@
 import strutils, algorithm, os, streams, json, sequtils, logging, times, tables, sets, strutils
 export strutils, algorithm, os, streams, json, sequtils, logging, times, tables, sets, strutils
 
+import std/exitprocs
+
 import neverwinter/util, neverwinter/resman,
   neverwinter/resref, neverwinter/key,
   neverwinter/resfile, neverwinter/resmemfile, neverwinter/resdir,
@@ -28,7 +30,7 @@ addHandler newFileLogger(stderr, fmtStr = "$levelid [$datetime] ")
 
 if isatty(stdout):
   hideCursor()
-  system.addQuitProc do () -> void {.noconv.}:
+  exitprocs.addExitProc do () -> void {.noconv.}:
     resetAttributes()
     showCursor()
 

--- a/private/shared.nim
+++ b/private/shared.nim
@@ -1,8 +1,6 @@
 import strutils, algorithm, os, streams, json, sequtils, logging, times, tables, sets, strutils
 export strutils, algorithm, os, streams, json, sequtils, logging, times, tables, sets, strutils
 
-import std/exitprocs
-
 import neverwinter/util, neverwinter/resman,
   neverwinter/resref, neverwinter/key,
   neverwinter/resfile, neverwinter/resmemfile, neverwinter/resdir,
@@ -28,11 +26,19 @@ const GffExtensions* = @[
 
 addHandler newFileLogger(stderr, fmtStr = "$levelid [$datetime] ")
 
-if isatty(stdout):
-  hideCursor()
-  exitprocs.addExitProc do () -> void {.noconv.}:
-    resetAttributes()
-    showCursor()
+when (NimMajor, NimMinor, NimPatch) >= (1, 4, 0):
+  import std/exitprocs
+  if isatty(stdout):
+    hideCursor()
+    exitprocs.addExitProc do () -> void {.noconv.}:
+      resetAttributes()
+      showCursor()
+  else:
+    if isatty(stdout):
+      hideCursor()
+      addQuitProc do () -> void {.noconv.}:
+        resetAttributes()
+        showCursor()
 
 import docopt as docopt_internal
 export docopt_internal


### PR DESCRIPTION
This fixes #25. Nim added UDP support to `asyncnet` in 1.4.0, which conflicted with `private/asyncnetudp`. I've changed it to use `asyncnet`. I don't know how to thoroughly test the changes, but the following yields the expected values:

```
$ nwn_net 145.239.204.29:5122 bnds
{
  "port": 5122,
  "serverDescription": "",
  "moduleDescription": "Arelith is a roleplaying server set in the Forgotten Realms circa 1372 DR. No custom content needed; new players are most welcome! Check out arelith.com for more information.",
  "serverVersion": "8193",
  "gameType": 3,
  "_querymsec": 144,
  "_queryhost": "145.239.204.29",
  "_queryport": 5122,
  "_localport": 39990,
  "_localhost": "0.0.0.0"
}
```