### PR TITLE
Fix warnings

### DIFF
--- a/neverwinter/erf.nim
+++ b/neverwinter/erf.nim
@@ -1,4 +1,4 @@
-import streams, strutils, sequtils, tables, times, algorithm, os, logging, std/sha1, std/oids
+import streams, strutils, sequtils, tables, times, algorithm, logging, std/sha1, std/oids
 
 import resman, util, resref, exo, compressedbuf
 

--- a/neverwinter/erf.nim
+++ b/neverwinter/erf.nim
@@ -65,7 +65,7 @@ proc readErf*(io: Stream, filename = "(anon-io)"): Erf =
     io.setPosition(io.getPosition + 16) # reserved cipher mp5 for RIM, unused these days.
     io.setPosition(io.getPosition + 100) # reserved
   of ErfVersion.E1:
-    result.oid = parseOid io.readStrOrErr(24)
+    result.oid = parseOid io.readStrOrErr(24).cstring
     io.setPosition(io.getPosition + 92) #reserved
 
   # locstrlist
@@ -158,7 +158,7 @@ proc writeErf*(io: Stream,
                strRef = 0,
                entries: seq[ResRef],
                # What OID to write out to the ERF. Defaults to no OID.
-               erfOid: Oid = parseOid(repeat("\x00", 24)),
+               erfOid: Oid = parseOid(repeat("\x00", 24).cstring),
                # This is called when we want you to write the binary data
                # of r:ResRef to io.
                writer: ErfEntryWriter) =

--- a/neverwinter/gff.nim
+++ b/neverwinter/gff.nim
@@ -1,4 +1,4 @@
-import strutils, sequtils, algorithm, streams, sugar, tables, sets, encodings,
+import strutils, sequtils, streams, sugar, tables, sets, encodings,
   typetraits
 
 import util, languages

--- a/neverwinter/key.nim
+++ b/neverwinter/key.nim
@@ -94,7 +94,7 @@ proc readBif(expectVersion: KeyBifVersion, expectOid: Oid, io: Stream, owner: Ke
   let variableTableOffset = io.readInt32()
 
   if expectVersion == KeyBifVersion.E1:
-    result.oid = parseOid io.readStrOrErr(24)
+    result.oid = parseOid io.readStrOrErr(24).cstring
     expect(result.oid == expectOid, "bif oid (" & $result.oid & ") mismatches key oid (" & $expectOid & ")")
 
   expect(fixedResCount == 0, "fixed resources in bif not supported")
@@ -206,7 +206,7 @@ proc readKeyTable*(io: Stream, label: string, resolveBif: proc (fn: string): Str
   result.buildYear = io.readInt32()
   result.buildDay = io.readInt32()
   if result.version == KeyBifVersion.E1:
-    result.oid = parseOid io.readStrOrErr(24)
+    result.oid = parseOid io.readStrOrErr(24).cstring
     io.setPosition(io.getPosition + 8) # reserved bytes
   else:
     io.setPosition(io.getPosition + 32) # reserved bytes

--- a/neverwinter/key.nim
+++ b/neverwinter/key.nim
@@ -1,4 +1,4 @@
-import streams, options, sequtils, strutils, tables, times, os, sets, math, std/sha1, std/oids
+import streams, sequtils, strutils, tables, times, os, sets, math, std/sha1, std/oids
 doAssert(($genOid()).len == 24)
 
 import resman, util, compressedbuf, exo

--- a/neverwinter/languages.nim
+++ b/neverwinter/languages.nim
@@ -1,4 +1,4 @@
-import tables, strutils, sequtils
+import tables, strutils
 
 type
   StrRef* = uint32

--- a/neverwinter/lru.nim
+++ b/neverwinter/lru.nim
@@ -1,4 +1,4 @@
-import lists, tables, options, strutils, logging
+import lists, tables, options, logging
 
 ## This is a weighted LRU cache. It works just like a regular, plain
 ## LRU cache, except you can specify the weight of each item manually.

--- a/neverwinter/resdir.nim
+++ b/neverwinter/resdir.nim
@@ -2,7 +2,7 @@
 ## are available live (meaning that adding files makes them available immediately).
 ## This may change in the future.
 
-import streams, strutils, os, logging
+import streams, os
 
 import resman
 

--- a/neverwinter/resfile.nim
+++ b/neverwinter/resfile.nim
@@ -1,7 +1,7 @@
 ## A ResFile is a single file mapped into resman: it needs to live in the
 ## file system and remain accessible.
 
-import streams, strutils, os
+import streams, os
 
 import resman
 

--- a/neverwinter/resmemfile.nim
+++ b/neverwinter/resmemfile.nim
@@ -1,4 +1,4 @@
-import streams, strutils, os, times
+import streams, times
 
 import resman
 

--- a/neverwinter/resref.nim
+++ b/neverwinter/resref.nim
@@ -1,4 +1,4 @@
-import tables, strutils, options
+import strutils, options
 from hashes import hash, Hash, `!&`
 
 import restype, util
@@ -75,4 +75,3 @@ proc `cmp`*[T: ResRef](a, b: T): int {.procvar.} =
   # This matters for sorting things like "_" versus "A".
   if a.resType != b.resType: return a.resType.int - b.resType.int
   else: return cmpIgnoreCase(a.resRef, b.resRef)
-

--- a/nwn_erf.nim
+++ b/nwn_erf.nim
@@ -97,7 +97,7 @@ if args["-c"]:
       exocomp = dataExoComp, compalg = dataCompAlg,
       locStrings = initTable[int, string](),
       strRef = 0, entries = entries,
-      erfOid = parseOid(repeat("\x00", 24))) do (r: ResRef, io: Stream) -> (int, SecureHash):
+      erfOid = parseOid(repeat("\x00", 24).cstring)) do (r: ResRef, io: Stream) -> (int, SecureHash):
 
     if verbose: echo r
     let data = readFile(resRefToFile[r])

--- a/nwn_erf_tlkify.nim
+++ b/nwn_erf_tlkify.nim
@@ -148,7 +148,7 @@ proc tlkify(ein: Erf, outFile: string) =
       dataExoComp, dataCompAlg,
       ein.locStrings,
       ein.strRef, toSeq(ein.contents.items),
-      parseOid(repeat("\x00", 24))) do (r: ResRef, io: Stream) -> (int, SecureHash):
+      parseOid(repeat("\x00", 24).cstring)) do (r: ResRef, io: Stream) -> (int, SecureHash):
 
     let ff = ein.demand(r)
     ff.seek()

--- a/nwn_net.nim
+++ b/nwn_net.nim
@@ -1,5 +1,5 @@
-import arpie, net, strutils, sequtils, os, jser, docopt, times
-import net, asyncdispatch, netutil, nativesockets
+import arpie, net, strutils, os, jser, docopt, times
+import asyncdispatch, netutil, nativesockets
 import shared
 
 when (NimMajor, NimMinor, NimPatch) >= (1, 4, 0):

--- a/private/progressbar.nim
+++ b/private/progressbar.nim
@@ -1,4 +1,4 @@
-import terminal, sets, math, strutils, streams
+import terminal, sets, math, strutils
 
 type ProgressBar = ref object
   label: string


### PR DESCRIPTION
Fix compiler warnings about implicit conversion to cstring [CStringConv] and unused imports. The CStringConv warning is only in nim 1.6.0 but why not prepare ;)