### PR TITLE
nwn_twoda: Add minify option for 2da output

### DIFF
--- a/neverwinter/twoda.nim
+++ b/neverwinter/twoda.nim
@@ -4,6 +4,7 @@ import resman, resref, util
 
 const
   CellPadding = 2
+  CellPaddingMini = 1
   MaxColumns = 1024 # im a hack
   TwodaHeader = "2DA V2.0"
 
@@ -209,7 +210,7 @@ proc escapeField*(field: Cell): string =
     else:
       fd
 
-proc writeTwoDA*(io: Stream, self: TwoDA) =
+proc writeTwoDA*(io: Stream, self: TwoDA, minify = false) =
   ## Writes a twoda to the stream. Attempts to format the twoda to look pretty.
 
   if self.headers.len == 0:
@@ -232,22 +233,22 @@ proc writeTwoDA*(io: Stream, self: TwoDA) =
   if self.defaultValue.isSome: io.write("DEFAULT: " & self.defaultValue.escapeField)
   io.write("\c\L")
 
-  io.write(repeat(" ", idWidth + CellPadding))
+  io.write(repeat(" ", if minify: CellPaddingMini else: idWidth + CellPadding))
   for idx, h in self.headers:
     io.write(h)
     if idx != self.headers.len - 1:
-      io.write(repeat(" ", maxColWidth[idx] - h.len + 3 + CellPadding))
+      io.write(repeat(" ", if minify: CellPaddingMini else: maxColWidth[idx] - h.len + 3 + CellPadding))
   io.write("\c\L")
 
   for rowidx, row in self.rows:
     let thisId = $rowIdx
-    io.write(thisId & repeat(" ", idWidth + CellPadding - thisId.len))
+    io.write(thisId & repeat(" ", if minify: CellPaddingMini else: idWidth + CellPadding - thisId.len))
 
     for cellidx, cell in row:
       let fmt = cell.escapeField
       io.write(fmt.toNwnEncoding)
       if cellidx != self.headers.len - 1:
-        io.write(repeat(" ", maxColWidth[cellidx] - fmt.len + 3 + CellPadding))
+        io.write(repeat(" ", if minify: CellPaddingMini else: maxColWidth[cellidx] - fmt.len + 3 + CellPadding))
     io.write("\c\L")
 
 proc as2DA*(self: Res): TwoDA =

--- a/nwn_twoda.nim
+++ b/nwn_twoda.nim
@@ -29,6 +29,8 @@ Options:
   -o OUT                      Output file [default: -]
   -k OUTFORMAT                Output format [default: autodetect]
 
+  --minify                    Minifies 2da output using minimal padding instead of using pretty formatting.
+
   --csv-separator SEP         What to use as separator for CSV cells [default: ,]
 
   --write-id-column           Generate ID column when exporting non-2da formats.
@@ -94,6 +96,6 @@ of "csv":    state = input.readCsv()
 else: quit("Unsupported informat: " & informat)
 
 case outformat:
-of "2da":    output.writeTwoDA(state)
+of "2da":    output.writeTwoDA(state, args["--minify"])
 of "csv":   output.writeCsv(state)
 else: quit("Unsupported outformat: " & outformat)

--- a/tests/test_twoda.nim
+++ b/tests/test_twoda.nim
@@ -181,6 +181,16 @@ suite "TwoDA writing":
     let all = io.readAll
     check(-1 != all.find("LongValue     B"))
 
+  test "write minified does not pad out columns to max width of cells":
+    var tda = newTwoDA()
+    tda.columns = @["A", "B"]
+    tda[0] = @[some "LongValue", some "B"]
+    var io = newStringStream()
+    io.writeTwoDA(tda, true)
+    io.setPosition(0)
+    let all = io.readAll
+    check(-1 != all.find("LongValue B"))
+
   test "writes out with CRLF":
     var tda = newStringStream(TwodaHeader & "\n\nA B\n0 a b").readTwoDA()
     var io = newStringStream()


### PR DESCRIPTION
Adds a command line option for minifying 2da output without column padding.
For large 2das, this can see a significant file size reduction.

Usage:
```
nwn_twoda -i "file.csv" -o "file.2da" --minify
```