### PR TITLE
gff/gffjson: revert cast changes and silence warnings

### DIFF
--- a/neverwinter/gff.nim
+++ b/neverwinter/gff.nim
@@ -241,13 +241,14 @@ proc getValue*[T: GffFieldType](self: GffField, t: typedesc[T]): T =
   else: {.fatal: "You added a gff type but didn't make it resolvable in getValue()"}
 
 proc assignValue*[T: GffFieldType](self: GffField, v: T) =
-  when T is GffByte: self.dataOrOffset = v.int32
-  elif T is GffChar: self.dataOrOffset = v.int32
-  elif T is GffWord: self.dataOrOffset = v.int32
-  elif T is GffShort: self.dataOrOffset = v.int32
-  elif T is GffDword: self.dataOrOffset = v.int32
-  elif T is GffInt: self.dataOrOffset = v.int32
-  elif T is GffFloat: self.dataOrOffset = v.int32
+  {.warning[CastSizes]: off.}
+  when T is GffByte: self.dataOrOffset = cast[int32](v)
+  elif T is GffChar: self.dataOrOffset = cast[int32](v)
+  elif T is GffWord: self.dataOrOffset = cast[int32](v)
+  elif T is GffShort: self.dataOrOffset = cast[int32](v)
+  elif T is GffDword: self.dataOrOffset = cast[int32](v)
+  elif T is GffInt: self.dataOrOffset = cast[int32](v)
+  elif T is GffFloat: self.dataOrOffset = cast[int32](v)
 
   elif T is GffDword64: self.gffDword64 = v
   elif T is GffInt64: self.gffInt64 = v
@@ -259,6 +260,7 @@ proc assignValue*[T: GffFieldType](self: GffField, v: T) =
   elif T is GffStruct: self.gffStruct = v
   elif T is GffVoid: self.gffVoid = v
   else: {.fatal: "You added a gff type but didn't make it resolvable in assignValue()"}
+  {.warning[CastSizes]: on.}
 
 proc newGffList*(): GffList = newSeq[GffStruct]()
 


### PR DESCRIPTION
This reverts the changes introduced by e74f3fe and silences the warnings instead. Fixes #62.

The warning should not need to be silenced after nim-lang/Nim@d139d99 hits stable.