### PR TITLE
scriptcomp: Support constant folding everywhere

### DIFF
--- a/neverwinter/nwscript/native/scriptcomp.h
+++ b/neverwinter/nwscript/native/scriptcomp.h
@@ -525,6 +525,8 @@ private:
 	CScriptParseTreeNode *m_pGlobalVariableParseTree;
 	int32_t AddToGlobalVariableList(CScriptParseTreeNode *pGlobalVariableNode);
 
+	BOOL ConstantFoldNode(CScriptParseTreeNode *pNode);
+
 	BOOL m_bConstantVariableDefinition;
 
 	int32_t m_nLoopIdentifier;

--- a/neverwinter/nwscript/native/scriptcompfinalcode.cpp
+++ b/neverwinter/nwscript/native/scriptcompfinalcode.cpp
@@ -1035,6 +1035,7 @@ int32_t CScriptCompiler::TraverseTreeForSwitchLabels(CScriptParseTreeNode *pNode
 	{
 		int32_t nCaseValue;
 
+		ConstantFoldNode(pNode->pLeft);
 		// Evaluate the constant value that is contained.
 		if (pNode->pLeft != NULL &&
 		        pNode->pLeft->nOperation == CSCRIPTCOMPILER_OPERATION_NEGATION &&
@@ -1345,6 +1346,7 @@ int32_t CScriptCompiler::GenerateIdentifiersFromConstantVariables(CScriptParseTr
 			        pNode->pRight->pLeft->pLeft->pLeft != NULL)
 			{
 				CScriptParseTreeNode *pNodeConstant = pNode->pRight->pLeft->pLeft->pLeft;
+				ConstantFoldNode(pNodeConstant);
 
 				int32_t nConstantOperation = pNodeConstant->nOperation;
 				int32_t nSign = 1;
@@ -1687,6 +1689,7 @@ int32_t CScriptCompiler::PreVisitGenerateCode(CScriptParseTreeNode *pNode)
 	{
 		int32_t nCaseValue;
 
+			ConstantFoldNode(pNode->pLeft);
 		// Evaluate the constant value that is contained.
 		if (pNode->pLeft != NULL &&
 		        pNode->pLeft->nOperation == CSCRIPTCOMPILER_OPERATION_NEGATION &&
@@ -7864,6 +7867,7 @@ int32_t CScriptCompiler::WalkParseTree(CScriptParseTreeNode *pNode)
 
 		int nReturnCode;
 
+		ConstantFoldNode(pNode);
 		nReturnCode = PreVisitGenerateCode(pNode);
 
 		if (nReturnCode == 0)
@@ -7873,6 +7877,7 @@ int32_t CScriptCompiler::WalkParseTree(CScriptParseTreeNode *pNode)
 
 		if (nReturnCode == 0)
 		{
+			ConstantFoldNode(pNode);
 			nReturnCode = InVisitGenerateCode(pNode);
 		}
 
@@ -7883,6 +7888,7 @@ int32_t CScriptCompiler::WalkParseTree(CScriptParseTreeNode *pNode)
 
 		if (nReturnCode == 0)
 		{
+			ConstantFoldNode(pNode);
 			nReturnCode = PostVisitGenerateCode(pNode);
 		}
 

--- a/tests/scriptcomp/corpus/constants.nss
+++ b/tests/scriptcomp/corpus/constants.nss
@@ -16,4 +16,48 @@ const string STRING_LITERAL_ESCAPE_NEWLINE = "\n";
 const string STRING_LITERAL_ESCAPE_QUOTE = "\"";
 const string STRING_LITERAL_ESCAPE_HEX = "\x07";
 
+// Constant folding
+const int A = 10;
+const int B = A + A;
+
+const int CONSTINT_LOGICAL_OR          = A || B;
+const int CONSTINT_LOGICAL_AND         = A && B;
+const int CONSTINT_INCLUSIVE_OR        = A |  B;
+const int CONSTINT_EXCLUSIVE_OR        = A ^  B;
+const int CONSTINT_BOOLEAN_AND         = A &  B;
+const int CONSTINT_CONDITION_EQUAL     = A == B;
+const int CONSTINT_CONDITION_NOT_EQUAL = A != B;
+const int CONSTINT_CONDITION_GEQ       = A >= B;
+const int CONSTINT_CONDITION_GT        = A >  B;
+const int CONSTINT_CONDITION_LT        = A <  B;
+const int CONSTINT_CONDITION_LEQ       = A <= B;
+const int CONSTINT_SHIFT_LEFT          = A << B;
+const int CONSTINT_SHIFT_RIGHT         = A >> B;
+const int CONSTINT_ADD                 = A +  B;
+const int CONSTINT_SUBTRACT            = A -  B;
+const int CONSTINT_MULTIPLY            = A *  B;
+const int CONSTINT_DIVIDE              = A /  B;
+const int CONSTINT_MODULUS             = A %  B;
+
+const float X = 10.0f;
+const float Y = X + X;
+
+const float CONSTFLOAT_ADD                 = X +  Y;
+const float CONSTFLOAT_SUBTRACT            = X -  Y;
+const float CONSTFLOAT_MULTIPLY            = X *  Y;
+const float CONSTFLOAT_DIVIDE              = X /  Y;
+const int   CONSTFLOAT_CONDITION_EQUAL     = X == Y;
+const int   CONSTFLOAT_CONDITION_NOT_EQUAL = X != Y;
+const int   CONSTFLOAT_CONDITION_GEQ       = X >= Y;
+const int   CONSTFLOAT_CONDITION_GT        = X >  Y;
+const int   CONSTFLOAT_CONDITION_LT        = X <  Y;
+const int   CONSTFLOAT_CONDITION_LEQ       = X <= Y;
+
+const string S1 = "AAA";
+const string S2 = "BBB";
+const string S3 = S1 + "_" + S2;
+
+const int CONSTSTR_CONDITION_EQUAL     = S1 == S2;
+const int CONSTSTR_CONDITION_NOT_EQUAL = S1 != S2;
+
 void main() {}

--- a/tests/scriptcomp/corpus/switch.nss
+++ b/tests/scriptcomp/corpus/switch.nss
@@ -1,0 +1,18 @@
+const int N = 10;
+const string S = "nwn";
+
+void main()
+{
+    int n;
+    switch (n)
+    {
+        case N:   break;
+        case N+1: break;
+        case 1:   break;
+        case 1+1: break;
+        case -1:  break;
+        case -N:  break;
+        case S:   break;
+        case S+S: break;
+    }
+}


### PR DESCRIPTION
Resolves #51 

How this works is that every time we have a parse subtree that looks something like
```
     OP
  /      \
CONST  CONST
```
e.g. `3+2`, it is replaced with a single `CONST` node (5). It depth-first tries to fold lower level nodes, and only if both childs are consts it tries to fold current node.
This is always safe to call and is a pretty cheap op, so we call it at every stage of the codegen visits.

Because this is done on the AST before any sort of codegen, it applies everywhere where such an expression can be found - both `const` declarations and within the code. Only special case is the `case` of a switch statement, that needed a manual extra fold call.

Added a test suite for every operator, and verified (by looking at disassembly) that the folded values are what is expected.

# Changelog

## Changed
- nwscript: `const` declarations can now contain any constant expression, including previously defined consts.

## Performance Improvements
- nwscript: Where possible, expressions are now evaluated at compile time instead of runtime

---
This patch is released as a dual MIT and WTFPL-2 license :)