### PR TITLE
nwasm: decode DE_STRUCT instruction special data

### DIFF
--- a/neverwinter/nwscript/nwasm.nim
+++ b/neverwinter/nwscript/nwasm.nim
@@ -141,6 +141,7 @@ proc `$`*(i: Instr): string =
   of RUNSTACK_COPY, RUNSTACK_COPY_BASE: $str.readInt32().swapEndian()
   of ASSIGNMENT, ASSIGNMENT_BASE: $str.readInt32().swapEndian() & ", " & $str.readUint16().swapEndian()
   of INCREMENT, DECREMENT, INCREMENT_BASE, DECREMENT_BASE: $str.readInt32().swapEndian()
+  of DE_STRUCT: $str.readUint16().swapEndian() & ", " & $str.readUint16().swapEndian() & ", " & $str.readUint16().swapEndian()
   else:
     if i.extra.len > 0:
       raise newException(Defect, "not implemented: " & i.extra.escape() & " for " & $i.op)


### PR DESCRIPTION
Printing out additional instruction data was missing a case for the `DE_STRUCT` instruction, which takes 3 uint16s.

## Testing

Disassembled https://github.com/niv/neverwinter.nim/blob/master/tests/scriptcomp/corpus/allinstructions.nss (disassembly in that file at the end)

## Changelog

### Fixed
- nwn_asm can now properly disassemble `DE_STRUCT` instructions

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
