### PR TITLE
scriptcomp: Hotfix m_nBinaryCodeLength broken by symbolic output removal

### DIFF
--- a/neverwinter/nwscript/native/scriptcompfinalcode.cpp
+++ b/neverwinter/nwscript/native/scriptcompfinalcode.cpp
@@ -5179,6 +5179,7 @@ int32_t CScriptCompiler::PostVisitGenerateCode(CScriptParseTreeNode *pNode)
 			m_pchOutputCode[m_nOutputCodeLength+CVIRTUALMACHINE_EXTRA_DATA_LOCATION+5] = (char) (((nSize)) & 0x0ff);
 
 			m_nOutputCodeLength += CVIRTUALMACHINE_OPERATION_BASE_SIZE + 6;
+			m_nBinaryCodeLength += CVIRTUALMACHINE_OPERATION_BASE_SIZE + 6;
 
 
 			// Add the "modify stack pointer" statement so that the return value is never used again.


### PR DESCRIPTION
Cut/paste error from #71. I'll be removing this variable entirely soon, but just a hotfix for now

## Testing

Test suite builds (though it did previously too) 

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
