### PR TITLE
scriptcomp: Delete m_nBinaryCodeLength

### DIFF
--- a/neverwinter/nwscript/native/scriptcomp.h
+++ b/neverwinter/nwscript/native/scriptcomp.h
@@ -599,7 +599,6 @@ private:
 	char       *m_pchOutputCode;
 	int32_t         m_nOutputCodeSize;
 	int32_t         m_nOutputCodeLength;
-	int32_t         m_nBinaryCodeLength;
 
 	// Resolving code to its proper location ... some buffers!
 	char       *m_pchResolvedOutputBuffer;

--- a/neverwinter/nwscript/native/scriptcompcore.cpp
+++ b/neverwinter/nwscript/native/scriptcompcore.cpp
@@ -640,7 +640,6 @@ void CScriptCompiler::Initialize( )
 	m_nStackCurrentDepth = 0;
 	m_bAssignmentToVariable = FALSE;
 	m_bInStructurePart = FALSE;
-	m_nBinaryCodeLength = 0;
 
 	ClearAllSymbolLists();
 

--- a/tests/scriptcomp/corpus/startingcond.nss
+++ b/tests/scriptcomp/corpus/startingcond.nss
@@ -1,0 +1,4 @@
+int StartingConditional()
+{
+    return TRUE;
+}


### PR DESCRIPTION
Delete m_nBinaryCodeLength variable, it is always equivalent to m_nOutputCodeLength. Back when we had asm-symbolized output as an option, OutputCodeLength counted the text length while the other one counted binary length. In regular mode they were always equivalent.

This is one of many refactoring changes needed to make future improvements easier.

## Testing

scriptcomp test suite, including the newly added StartingConditional test which would have caught previous bug here (#74)

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
