### PR TITLE
scriptcomp: Keep track of instruction boundaries as they're written

### DIFF
--- a/neverwinter/nwscript/native/scriptcomp.h
+++ b/neverwinter/nwscript/native/scriptcomp.h
@@ -599,6 +599,7 @@ private:
 	char       *m_pchOutputCode;
 	int32_t         m_nOutputCodeSize;
 	int32_t         m_nOutputCodeLength;
+	std::vector<int32_t> m_aOutputCodeInstructionBoundaries;
 
 	// Resolving code to its proper location ... some buffers!
 	char       *m_pchResolvedOutputBuffer;


### PR DESCRIPTION
So I lied when I said the goal was to refactor all the instruction writing into separate functions, then add instruction tracking and optimizations. The endgame is still the same, but I realized that there would be a ton of busywork needed to be done before we ever see a meaningful change.

Instead, I'm adding instruction tracking right now, in 97 different places. Every time we advance the m_nOutputCodeLength when we're done with an instruction, we also push that to a new stack (vector).

Now we can easily check what the last instruction was, and either modify it or change which next one gets emitted. We can even reorder the already written ones. After this change I can start working on optimizations and refactor in parallel - move instructions one at a time to the Emit() pattern, and add optimizations while at it.

## Testing

Added this basic disassembly bit at compile cleanup:
```c++
    for (int32_t inst : m_aOutputCodeInstructionBoundaries)
    {
        printf("% 3d    ", inst);
        switch (m_pchOutputCode[inst])
        {
            case CVIRTUALMACHINE_OPCODE_ASSIGNMENT:                printf("ASSIGNMENT\n"); break;
            case CVIRTUALMACHINE_OPCODE_RUNSTACK_ADD:              printf("RUNSTACK_ADD\n"); break;
            case CVIRTUALMACHINE_OPCODE_RUNSTACK_COPY:             printf("RUNSTACK_COPY\n"); break;
            case CVIRTUALMACHINE_OPCODE_CONSTANT:                  printf("CONSTANT\n"); break;
            case CVIRTUALMACHINE_OPCODE_EXECUTE_COMMAND:           printf("EXECUTE_COMMAND\n"); break;
            case CVIRTUALMACHINE_OPCODE_LOGICAL_AND:               printf("LOGICAL_AND\n"); break;
            case CVIRTUALMACHINE_OPCODE_LOGICAL_OR:                printf("LOGICAL_OR\n"); break;
            case CVIRTUALMACHINE_OPCODE_INCLUSIVE_OR:              printf("INCLUSIVE_OR\n"); break;
            case CVIRTUALMACHINE_OPCODE_EXCLUSIVE_OR:              printf("EXCLUSIVE_OR\n"); break;
            case CVIRTUALMACHINE_OPCODE_BOOLEAN_AND:               printf("BOOLEAN_AND\n"); break;
            case CVIRTUALMACHINE_OPCODE_EQUAL:                     printf("EQUAL\n"); break;
            case CVIRTUALMACHINE_OPCODE_NOT_EQUAL:                 printf("NOT_EQUAL\n"); break;
            case CVIRTUALMACHINE_OPCODE_GEQ:                       printf("GEQ\n"); break;
            case CVIRTUALMACHINE_OPCODE_GT:                        printf("GT\n"); break;
            case CVIRTUALMACHINE_OPCODE_LT:                        printf("LT\n"); break;
            case CVIRTUALMACHINE_OPCODE_LEQ:                       printf("LEQ\n"); break;
            case CVIRTUALMACHINE_OPCODE_SHIFT_LEFT:                printf("SHIFT_LEFT\n"); break;
            case CVIRTUALMACHINE_OPCODE_SHIFT_RIGHT:               printf("SHIFT_RIGHT\n"); break;
            case CVIRTUALMACHINE_OPCODE_USHIFT_RIGHT:              printf("USHIFT_RIGHT\n"); break;
            case CVIRTUALMACHINE_OPCODE_ADD:                       printf("ADD\n"); break;
            case CVIRTUALMACHINE_OPCODE_SUB:                       printf("SUB\n"); break;
            case CVIRTUALMACHINE_OPCODE_MUL:                       printf("MUL\n"); break;
            case CVIRTUALMACHINE_OPCODE_DIV:                       printf("DIV\n"); break;
            case CVIRTUALMACHINE_OPCODE_MODULUS:                   printf("MODULUS\n"); break;
            case CVIRTUALMACHINE_OPCODE_NEGATION:                  printf("NEGATION\n"); break;
            case CVIRTUALMACHINE_OPCODE_ONES_COMPLEMENT:           printf("ONES_COMPLEMENT\n"); break;
            case CVIRTUALMACHINE_OPCODE_MODIFY_STACK_POINTER:      printf("MODIFY_STACK_POINTER\n"); break;
            case CVIRTUALMACHINE_OPCODE_STORE_IP:                  printf("STORE_IP\n"); break;
            case CVIRTUALMACHINE_OPCODE_JMP:                       printf("JMP\n"); break;
            case CVIRTUALMACHINE_OPCODE_JSR:                       printf("JSR\n"); break;
            case CVIRTUALMACHINE_OPCODE_JZ:                        printf("JZ\n"); break;
            case CVIRTUALMACHINE_OPCODE_RET:                       printf("RET\n"); break;
            case CVIRTUALMACHINE_OPCODE_DE_STRUCT:                 printf("DE_STRUCT\n"); break;
            case CVIRTUALMACHINE_OPCODE_BOOLEAN_NOT:               printf("BOOLEAN_NOT\n"); break;
            case CVIRTUALMACHINE_OPCODE_DECREMENT:                 printf("DECREMENT\n"); break;
            case CVIRTUALMACHINE_OPCODE_INCREMENT:                 printf("INCREMENT\n"); break;
            case CVIRTUALMACHINE_OPCODE_JNZ:                       printf("JNZ\n"); break;
            case CVIRTUALMACHINE_OPCODE_ASSIGNMENT_BASE:           printf("ASSIGNMENT_BASE\n"); break;
            case CVIRTUALMACHINE_OPCODE_RUNSTACK_COPY_BASE:        printf("RUNSTACK_COPY_BASE\n"); break;
            case CVIRTUALMACHINE_OPCODE_DECREMENT_BASE:            printf("DECREMENT_BASE\n"); break;
            case CVIRTUALMACHINE_OPCODE_INCREMENT_BASE:            printf("INCREMENT_BASE\n"); break;
            case CVIRTUALMACHINE_OPCODE_SAVE_BASE_POINTER:         printf("SAVE_BASE_POINTER\n"); break;
            case CVIRTUALMACHINE_OPCODE_RESTORE_BASE_POINTER:      printf("RESTORE_BASE_POINTER\n"); break;
            case CVIRTUALMACHINE_OPCODE_STORE_STATE:               printf("STORE_STATE\n"); break;
            case CVIRTUALMACHINE_OPCODE_NO_OPERATION:              printf("NO_OPERATION\n"); break;
        }
    }
```
and verified it disassembles the same thing as nwn_asm.

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
