### PR TITLE
nwn_asm: Remove unused and nonexistent vm import

### DIFF
--- a/nwn_asm.nim
+++ b/nwn_asm.nim
@@ -1,7 +1,7 @@
 import std/streams
 
 import shared
-import neverwinter/nwscript/[nwasm, ndb, vm]
+import neverwinter/nwscript/[nwasm, ndb]
 
 let args = DOC """
 Disassemble ncs.


### PR DESCRIPTION
Regression from the test VM addition I guess.

## Testing

nwn_asm compiles where previously it didn't. It still works.

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
