### PR TITLE
scriptcomp: Optimize constant->variable assignment

### DIFF
--- a/neverwinter/nwscript/native/scriptcomp.h
+++ b/neverwinter/nwscript/native/scriptcomp.h
@@ -606,6 +606,8 @@ private:
 	int32_t         m_nOutputCodeLength;
 	std::vector<int32_t> m_aOutputCodeInstructionBoundaries;
 
+	char *InstructionLookback(uint32_t last=1);
+
 	// Resolving code to its proper location ... some buffers!
 	char       *m_pchResolvedOutputBuffer;
 	int32_t         m_nResolvedOutputBufferSize;

--- a/tests/scriptcomp/corpus/variables.nss
+++ b/tests/scriptcomp/corpus/variables.nss
@@ -1,0 +1,29 @@
+void main()
+{
+    int a = 1;
+    int b = 2;
+    int c = 3;
+    int d = 4;
+    string s = "A";
+    float f = 1.0f;
+
+    if (1)
+    {
+        int a = 10;
+        int b = 20;
+        int c = 30;
+        int d = 40;
+        string s = "B";
+        float f = 10.0f;
+
+        Assert(a = 10);
+        Assert(b = 20);
+        Assert(c = 30);
+        Assert(d = 40);
+    }
+
+    Assert(a = 1);
+    Assert(b = 2);
+    Assert(c = 3);
+    Assert(d = 4);
+}

--- a/tests/scriptcomp/corpus/variables.nss
+++ b/tests/scriptcomp/corpus/variables.nss
@@ -16,14 +16,18 @@ void main()
         string s = "B";
         float f = 10.0f;
 
-        Assert(a = 10);
-        Assert(b = 20);
-        Assert(c = 30);
-        Assert(d = 40);
+        Assert(a == 10);
+        Assert(b == 20);
+        Assert(c == 30);
+        Assert(d == 40);
+        Assert(s == "B");
+        Assert(f == 10.0f);
     }
 
-    Assert(a = 1);
-    Assert(b = 2);
-    Assert(c = 3);
-    Assert(d = 4);
+    Assert(a == 1);
+    Assert(b == 2);
+    Assert(c == 3);
+    Assert(d == 4);
+    Assert(s == "A");
+    Assert(f == 1.0f);
 }


### PR DESCRIPTION
The nwscript construct `int n = 3;` gets compiled into the following:
```
    RUNSTACK_ADD, TYPE_INTEGER
    CONSTANT, TYPE_INTEGER, 3
    ASSIGNMENT, TYPE_VOID, -8, 4
    MODIFY_STACK_POINTER, -4
```
This ends up with just the CONSTI 3 on the top of stack, but the
dance is necessary as `n = 3` is also an expression which returns 3.
Then, the last MODSP discards the result of the expression.
Here, we detect the pattern when it is discarded, and replace the
whole set of instructions with just CONSTI 3

Partial fix for #70 

## Testing

Added variables.nss test. Prior to this change, it got compiled into this mess (without asserts):
```
     0  JSR, 8                                  
     6  RET                                     
     8  RUNSTACK_ADD, TYPE_INTEGER              
    10  CONSTANT, TYPE_INTEGER, 1               
    16  ASSIGNMENT, TYPE_VOID, -8, 4            
    24  MODIFY_STACK_POINTER, -4                
    30  RUNSTACK_ADD, TYPE_INTEGER              
    32  CONSTANT, TYPE_INTEGER, 2               
    38  ASSIGNMENT, TYPE_VOID, -8, 4            
    46  MODIFY_STACK_POINTER, -4                
    52  RUNSTACK_ADD, TYPE_INTEGER              
    54  CONSTANT, TYPE_INTEGER, 3               
    60  ASSIGNMENT, TYPE_VOID, -8, 4            
    68  MODIFY_STACK_POINTER, -4                
    74  RUNSTACK_ADD, TYPE_INTEGER              
    76  CONSTANT, TYPE_INTEGER, 4               
    82  ASSIGNMENT, TYPE_VOID, -8, 4            
    90  MODIFY_STACK_POINTER, -4                
    96  RUNSTACK_ADD, TYPE_STRING               
    98  CONSTANT, TYPE_STRING, "A"              
   103  ASSIGNMENT, TYPE_VOID, -8, 4            
   111  MODIFY_STACK_POINTER, -4                
   117  RUNSTACK_ADD, TYPE_FLOAT                
   119  CONSTANT, TYPE_FLOAT, 1.0               
   125  ASSIGNMENT, TYPE_VOID, -8, 4            
   133  MODIFY_STACK_POINTER, -4                
   139  CONSTANT, TYPE_INTEGER, 1               
   145  JZ, 143                                 
   151  RUNSTACK_ADD, TYPE_INTEGER              
   153  CONSTANT, TYPE_INTEGER, 10              
   159  ASSIGNMENT, TYPE_VOID, -8, 4            
   167  MODIFY_STACK_POINTER, -4                
   173  RUNSTACK_ADD, TYPE_INTEGER              
   175  CONSTANT, TYPE_INTEGER, 20              
   181  ASSIGNMENT, TYPE_VOID, -8, 4            
   189  MODIFY_STACK_POINTER, -4                
   195  RUNSTACK_ADD, TYPE_INTEGER              
   197  CONSTANT, TYPE_INTEGER, 30              
   203  ASSIGNMENT, TYPE_VOID, -8, 4            
   211  MODIFY_STACK_POINTER, -4                
   217  RUNSTACK_ADD, TYPE_INTEGER              
   219  CONSTANT, TYPE_INTEGER, 40              
   225  ASSIGNMENT, TYPE_VOID, -8, 4            
   233  MODIFY_STACK_POINTER, -4                
   239  RUNSTACK_ADD, TYPE_STRING               
   241  CONSTANT, TYPE_STRING, "B"              
   246  ASSIGNMENT, TYPE_VOID, -8, 4            
   254  MODIFY_STACK_POINTER, -4                
   260  RUNSTACK_ADD, TYPE_FLOAT                
   262  CONSTANT, TYPE_FLOAT, 10.0              
   268  ASSIGNMENT, TYPE_VOID, -8, 4            
   276  MODIFY_STACK_POINTER, -28               
   282  JMP, 6                                  
   288  MODIFY_STACK_POINTER, -24               
   294  RET                                     
```
after the change, it becomes:
```
     0  JSR, 8                                  
     6  RET                                     
     8  CONSTANT, TYPE_INTEGER, 1               
    14  CONSTANT, TYPE_INTEGER, 2               
    20  CONSTANT, TYPE_INTEGER, 3               
    26  CONSTANT, TYPE_INTEGER, 4               
    32  CONSTANT, TYPE_STRING, "A"              
    37  CONSTANT, TYPE_FLOAT, 1.0               
    43  CONSTANT, TYPE_INTEGER, 1               
    49  JZ, 53                                  
    55  CONSTANT, TYPE_INTEGER, 10              
    61  CONSTANT, TYPE_INTEGER, 20              
    67  CONSTANT, TYPE_INTEGER, 30              
    73  CONSTANT, TYPE_INTEGER, 40              
    79  CONSTANT, TYPE_STRING, "B"              
    84  CONSTANT, TYPE_FLOAT, 10.0              
    90  MODIFY_STACK_POINTER, -24               
    96  JMP, 6                                  
   102  MODIFY_STACK_POINTER, -24               
   108  RET                            
```

## Changelog

### Performance Improvements
- nwscript compiler will now generate more optimal code for assigning values to variables

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
