### PR TITLE
scriptcomp: Optimize typical for loop construct instructions

### DIFF
--- a/neverwinter/nwscript/native/scriptcomp.h
+++ b/neverwinter/nwscript/native/scriptcomp.h
@@ -387,7 +387,9 @@ private:
 	int32_t InVisitGenerateCode(CScriptParseTreeNode *pNode);
 	int32_t PostVisitGenerateCode(CScriptParseTreeNode *pNode);
 
+	void WriteByteSwap16(char *buffer, int16_t value);
 	void WriteByteSwap32(char *buffer, int32_t value);
+	int16_t ReadByteSwap16(char *buffer);
 	int32_t ReadByteSwap32(char *buffer);
 	char *EmitInstruction(uint8_t nOpCode, uint8_t nAuxCode = 0, int32_t nDataSize = 0);
 	void EmitModifyStackPointer(int32_t nModifyBy);

--- a/neverwinter/nwscript/native/scriptcompfinalcode.cpp
+++ b/neverwinter/nwscript/native/scriptcompfinalcode.cpp
@@ -6981,9 +6981,18 @@ void CScriptCompiler::WriteByteSwap32(char *buffer, int32_t value)
 	buffer[2] = (char)((value >> 8)  & 0xff);
 	buffer[3] = (char)((value)       & 0xff);
 }
+void CScriptCompiler::WriteByteSwap16(char *buffer, int16_t value)
+{
+	buffer[0] = (char)((value >> 8)  & 0xff);
+	buffer[1] = (char)((value)       & 0xff);
+}
 int32_t CScriptCompiler::ReadByteSwap32(char *buffer)
 {
 	return ((int32_t)buffer[0] << 24) | ((int32_t)buffer[1] << 16) | ((int32_t)buffer[2] << 8) | (int32_t)buffer[3];
+}
+int16_t CScriptCompiler::ReadByteSwap16(char *buffer)
+{
+	return ((int16_t)buffer[0] << 8) | (int16_t)buffer[1];
 }
 
 char *CScriptCompiler::EmitInstruction(uint8_t nOpCode, uint8_t nAuxCode, int32_t nDataSize)
@@ -7047,6 +7056,34 @@ void CScriptCompiler::EmitModifyStackPointer(int32_t nModifyBy)
 				return;
 			}
 		}
+		// The common loop pattern of `for (i = 0; i < 1000; ++i)` gets compiled into
+		//     8  RUNSTACK_ADD, TYPE_STRING               
+		//    10  CONSTANT, TYPE_INTEGER, 0               
+		//    16  RUNSTACK_COPY, TYPE_VOID, -4, 4         
+		//    24  CONSTANT, TYPE_INTEGER, 1000            
+		//    30  LT, TYPETYPE_INTEGER_INTEGER            
+		//    32  JZ, 32                                  
+		//    38  INCREMENT, TYPE_INTEGER, -4             
+		//    44  RUNSTACK_COPY, TYPE_VOID, -4, 4         
+		//    52  MODIFY_STACK_POINTER, -4                
+		//    58  JMP, -42                                
+		// The inc/dec operations can reach all across the stack and don't need
+		// to be copied over to top of stack. However, since `++i` returns a value
+		// we have to emit the RUNSTACK_COPY. But, when we don't use that value,
+		// we just immediately clear it with MODIFY_STACK_POINTER.
+		// Just don't do either
+		if (last[CVIRTUALMACHINE_OPCODE_LOCATION] == CVIRTUALMACHINE_OPCODE_RUNSTACK_COPY)
+		{
+			int32_t nCopySize = ReadByteSwap16(&last[CVIRTUALMACHINE_EXTRA_DATA_LOCATION + 4]);
+			if ((nModifyBy + nCopySize) == 0)
+			{
+				// Undo RUNSTACK_COPY instruction
+				m_nOutputCodeLength -= (CVIRTUALMACHINE_OPERATION_BASE_SIZE + 6);
+				m_aOutputCodeInstructionBoundaries.pop_back();
+				return;
+			}
+		}
+
 	}
 
 	char *buf = EmitInstruction(CVIRTUALMACHINE_OPCODE_MODIFY_STACK_POINTER, 0, 4);

--- a/tests/scriptcomp/corpus/loops.nss
+++ b/tests/scriptcomp/corpus/loops.nss
@@ -6,6 +6,7 @@ void main()
 
     // Default for loop
     for (i = 0; i < 10; i++) {} Assert(i == 10);
+    for (i = 0; i < 10; ++i) {} Assert(i == 10);
     for (o = OBJECT_SELF; o != OBJECT_INVALID; o = OBJECT_INVALID) {} Assert(o == OBJECT_INVALID);
     for (f = 0.0f; f < 10.0f; f += 1.0f) {} Assert(f >= 10.0f);
 


### PR DESCRIPTION
The common loop pattern of `for (i = 0; i < 1000; ++i)` gets compiled into
```
     8  RUNSTACK_ADD, TYPE_STRING               
    10  CONSTANT, TYPE_INTEGER, 0               
    16  RUNSTACK_COPY, TYPE_VOID, -4, 4         
    24  CONSTANT, TYPE_INTEGER, 1000            
    30  LT, TYPETYPE_INTEGER_INTEGER            
    32  JZ, 32                                  
    38  INCREMENT, TYPE_INTEGER, -4             
    44  RUNSTACK_COPY, TYPE_VOID, -4, 4         
    52  MODIFY_STACK_POINTER, -4                
    58  JMP, -42                                
```
The inc/dec operations can reach all across the stack and don't need to be copied over to top of stack. However, since `++i` returns a value we have to emit the RUNSTACK_COPY. But, when we don't use that value, we just immediately clear it with MODIFY_STACK_POINTER. Just don't do either.

## Testing

Added an extra test case with ++i and runtime check on iteration count.
Verified disassembly of
```nss
void main() {
    int i;
    for (i = 0; i < 1000; ++i) { }
}
```
is sane.

## Changelog

### Performance Improvements
- Optimized the common for loop construct `for (i = 0; i < N; ++i)`

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
