### PR TITLE
Bunch of small fixes

### DIFF
--- a/neverwinter/game.nim
+++ b/neverwinter/game.nim
@@ -58,21 +58,22 @@ proc findNwnRoot*(override: string = ""): string =
       let settingsFile = getHomeDir() / r"AppData\Roaming\Beamdog Client\settings.json"
     else: {.fatal: "Unsupported os for findNwnRoot"}
 
-    let data = readFile(settingsFile)
-    let j = data.parseJson
-    doAssert(j.hasKey("folders"))
-    doAssert(j["folders"].kind == JArray)
+    if fileExists(settingsFile):
+      let data = readFile(settingsFile)
+      let j = data.parseJson
+      doAssert(j.hasKey("folders"))
+      doAssert(j["folders"].kind == JArray)
 
-    # 00785: Stable
-    # 00829: Development
-    const releases = ["00829", "00785"]
-    for torrentId in releases:
-      var fo = j["folders"].mapIt(it.str / torrentId)
+      # 00785: Stable
+      # 00829: Development
+      const releases = ["00829", "00785"]
+      for torrentId in releases:
+        var fo = j["folders"].mapIt(it.str / torrentId)
 
-      fo.keepItIf(dirExists(it))
-      if fo.len > 0:
-        result = fo[0]
-        break
+        fo.keepItIf(dirExists(it))
+        if fo.len > 0:
+          result = fo[0]
+          break
 
   if result == "" or not dirExists(result):
     raise newException(ValueError, "Could not locate NWN; try --root")

--- a/neverwinter/game.nim
+++ b/neverwinter/game.nim
@@ -41,7 +41,7 @@ proc findNwnRoot*(override: string = ""): string =
     elif defined(linux):
       let steamapps = r"~/.local/share/Steam/steamapps/common".expandTilde
     elif defined(windows):
-      let steamapps = r"c:\program files\steam\steamapps\common"
+      let steamapps = r"c:\program files (x86)\steam\steamapps\common"
     else: {.fatal: "Unsupported os for findNwnRoot".}
 
     if dirExists(steamapps / "Neverwinter Nights" / "data") and

--- a/private/shared.nim
+++ b/private/shared.nim
@@ -114,7 +114,8 @@ proc DOC*(body: string): OptArgs =
 proc newBasicResMan*(
     root = findNwnRoot(if Args["--root"]: $Args["--root"] else: ""),
     user = findUserRoot(if Args["--userdirectory"]: $Args["--userdirectory"] else: ""),
-    language = "", cacheSize = 0): ResMan =
+    language = if Args["--language"]: $Args["--language"] else : "en",
+    cacheSize = 0): ResMan =
   ## Sets up a resman that defaults to what EE looks like.
   ## Will load an additional language directory, if language is given.
 


### PR DESCRIPTION
Just some small fixes:
- The default steam install path for windows is in `Program Files (x86)`.
- If it couldn't find the beamdog client settings.json it'd throw an IOError, now it actually gets to the `try --root` suggestions.
- The default resman instance didn't do anything with the `--language` arg, not even defaulting to `en`

## Testing

It compiled and nwn_script_comp.exe found my steam folder and defaulted the resman language to en.

## Changelog

### Fixed

- Fixed the default steam path for Windows.
- Fixed a crash when the Beamdog Client settings.json file could not be found.
- Fixed `--language` not defaulting to `en` and overrides not working at all.

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.