### PR TITLE
scriptcomp: Don't generate dead MOVSP instructions when returning [WIP]

### DIFF
--- a/neverwinter/nwscript/native/scriptcompfinalcode.cpp
+++ b/neverwinter/nwscript/native/scriptcompfinalcode.cpp
@@ -5446,7 +5446,7 @@ int32_t CScriptCompiler::PostVisitGenerateCode(CScriptParseTreeNode *pNode)
 		// Write the MODIFY_STACK_POINTER instruction to modify the stack.
 
 		pNode->nIntegerData = (m_nFunctionImpAbortStackPointer - m_nStackCurrentDepth) * 4;
-		//m_nStackCurrentDepth = m_nFunctionImpAbortStackPointer;
+		m_nStackCurrentDepth = m_nFunctionImpAbortStackPointer;
 
 		if (pNode->nIntegerData != 0)
 		{


### PR DESCRIPTION
I don't know why this was disabled originally. Needs more testing before merging, leaving here as a WIP so others can test too.

## Testing

Test suite, plus disassembly. More tests TBD.

## Changelog

### Fixed
- Compiler will no longer generate dead MOVSP instructions when returning from a function


## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
