### PR TITLE
scriptcomp: Temporarily disable MOVSP merging

### DIFF
--- a/neverwinter/nwscript/native/scriptcompfinalcode.cpp
+++ b/neverwinter/nwscript/native/scriptcompfinalcode.cpp
@@ -7004,6 +7004,11 @@ void CScriptCompiler::EmitModifyStackPointer(int32_t nModifyBy)
 	if (m_nOptimizationFlags & CSCRIPTCOMPILER_OPTIMIZE_MELD_INSTRUCTIONS)
 	{
 		char *last = InstructionLookback(1);
+
+		// Temporarily disabled. Compiler is generating dead MOVSP instructions
+		// in some cases when returning from a function, and merging a live one
+		// with a dead one causes issues, unsurprisingly.
+#if 0
 		// Multiple MODIFY_STACK_POINTER instructions can always be merged into a single one
 		if (last[CVIRTUALMACHINE_OPCODE_LOCATION] == CVIRTUALMACHINE_OPCODE_MODIFY_STACK_POINTER)
 		{
@@ -7012,7 +7017,7 @@ void CScriptCompiler::EmitModifyStackPointer(int32_t nModifyBy)
 			WriteByteSwap32(&last[CVIRTUALMACHINE_EXTRA_DATA_LOCATION], mod);
 			return;
 		}
-
+#endif
 		// The nwscript construct `int n = 3;` gets compiled into the following:
 		//     RUNSTACK_ADD, TYPE_INTEGER
 		//     CONSTANT, TYPE_INTEGER, 3

--- a/tests/scriptcomp/corpus/functions.nss
+++ b/tests/scriptcomp/corpus/functions.nss
@@ -1,0 +1,30 @@
+string foo(int arg)
+{
+    return IntToString(arg);
+}
+
+int multiple_return_paths(int arg)
+{
+    int a;
+    if (arg == 0)
+    {
+        int b;
+        return 0;
+    }
+    if (arg == 1)
+    {
+        int c;
+        return 1;
+    }
+
+    return -1;
+}
+void main()
+{
+    string s = foo(12);
+    Assert(s == "12", "foo");
+
+    int n0 = multiple_return_paths(0); Assert(n0 == 0, "n0");
+    int n1 = multiple_return_paths(1); Assert(n1 == 1, "n1");
+    int n2 = multiple_return_paths(2); Assert(n2 == -1, "n2");
+}


### PR DESCRIPTION
Compiler is generating dead MOVSP instructions in some cases when returning from a function, and merging a live one with a dead one causes issues, unsurprisingly.

So, disabling merging until #89 is implemented properly.

## Testing

Added a test case that fails at TOT but passes with this change

## Changelog

### Fixed
- Fixed STACK_UNDERFLOW errors when compiling with `-O2`

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
