### PR TITLE
script_comp: add optional include sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Script compiler: Optional `-i <inc>` dir or file, which are added to the search path for includes but not compiled.
+
 ## [1.6.4] - 2023-10-14
 
 ### Added


### PR DESCRIPTION
Resolves #98 by adding an optional arg `-i`, either file or directory. Adds these files or directories to the search path for includes. Can include multiples with the separator `;`, which I do not love given it's the command separator in terminals, but it matched the issue's proposed separator: `-i some/file.nss;some/dir`. Please suggest better alternative.

## Testing

Compiled test scripts with includes located in unrelated file locations both directly to file.nss and generally to /dir. Also confirmed compiling without `-i` operates as expected.

## Changelog
### Added
- Script compiler: Optional `-i` directory or file paths, which are added to the search path for includes but not compiled. Separate multiple paths `;` i.e. `-i some/file.nss;some/dir`

## Licence

- [X] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
