### PR TITLE
scriptcomp: Extend token size to 64kb

### DIFF
--- a/neverwinter/nwscript/native/scriptcomp.h
+++ b/neverwinter/nwscript/native/scriptcomp.h
@@ -37,7 +37,7 @@ class CScriptCompilerIdentifierHashTableEntry;
 
 // Defines required for static size of values.
 #define CSCRIPTCOMPILER_MAX_TABLE_FILENAMES  512
-#define CSCRIPTCOMPILER_MAX_TOKEN_LENGTH     8192
+#define CSCRIPTCOMPILER_MAX_TOKEN_LENGTH     65536
 #define CSCRIPTCOMPILER_INCLUDE_LEVELS       16
 #define CSCRIPTCOMPILER_MAX_INCLUDE_LEVELS   200   // gcc also defaults to 200.
 #define CSCRIPTCOMPILER_MAX_RUNTIME_VARS     8192

--- a/neverwinter/nwscript/native/scriptcompcore.cpp
+++ b/neverwinter/nwscript/native/scriptcompcore.cpp
@@ -1639,6 +1639,7 @@ BOOL CScriptCompiler::ConstantFoldNode(CScriptParseTreeNode *pNode, BOOL bForce)
 				//
 				if ((left.GetLength() + right.GetLength()) >= 0x8000)
 					return FALSE;
+				assert(CSCRIPTCOMPILER_MAX_TOKEN_LENGTH >= 0x8000);
 				result = left +  right;
 				break;
 			}

--- a/tests/scriptcomp/corpus/constants.nss
+++ b/tests/scriptcomp/corpus/constants.nss
@@ -60,6 +60,22 @@ const string S3 = S1 + "_" + S2;
 const int CONSTSTR_CONDITION_EQUAL     = S1 == S2;
 const int CONSTSTR_CONDITION_NOT_EQUAL = S1 != S2;
 
+// Concatenating large strings:
+const string S16 = "0123456789ABCDEF";
+const string S64 = S16 + S16 + S16 + S16;
+const string S256 = S64 + S64 + S64 + S64;
+const string S1K = S256 + S256 + S256 + S256;
+const string S4K = S1K + S1K + S1K + S1K;
+const string S16K = S4K + S4K + S4K + S4K;
+// Max *const* string size is 32k
+const string S32KminusOne = S16K +
+                            S4K + S4K + S4K +
+                            S1K + S1K + S1K +
+                            S256 + S256 + S256 +
+                            S64 + S64 + S64 +
+                            S16 + S16 + S16 +
+                            "0123456789ABCDE";
+
 // Raw strings
 const string RAW_STRING_SIMPLE_LOWERCASE = r"Neverwinter\nNights";
 const string RAW_STRING_SIMPLE_UPPERCASE = R"Neverwinter\nNights";
@@ -107,4 +123,6 @@ void main()
     Assert(RAW_STRING_MULTILINE == "AAA\nBBB\nCCC");
     Assert(RAW_STRING_QUOTE == "_\"_");
 
+    // non-const strings can be larger than 32k
+    string S64k = S16K + S16K + S16K + S16K;
 }


### PR DESCRIPTION
When constant folding strings the result has to fit in m_pchToken, so increase the token length. While the string itself is limited to 32k, rounding up the token size to 64k to account for off by ones and whatnot. This same change has been applied to basegame already.

Reusing changelog entry from #102 

## Testing

Added a new test case

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
