### PR TITLE
Only use checksums package on Nim >= 2

### DIFF
--- a/neverwinter.nimble
+++ b/neverwinter.nimble
@@ -6,8 +6,8 @@ description   = "Neverwinter Nights 1: Enhanced Edition data accessor library an
 license       = "MIT"
 
 requires "nim >= 1.6.4"
-requires "checksums"
 when NimMajor == 2:
+  requires "checksums"
   requires "https://github.com/docopt/docopt.nim#head"
   requires "db_connector >= 0.1.0"
 else:

--- a/neverwinter/erf.nim
+++ b/neverwinter/erf.nim
@@ -1,6 +1,6 @@
-import streams, strutils, tables, times, algorithm, logging, checksums/sha1, std/oids
+import streams, strutils, tables, times, algorithm, logging, std/oids
 
-import resman, util, resref, exo, compressedbuf
+import resman, util, resref, exo, compressedbuf, checksums
 
 # This is advisory only. We will emit a warning on mismatch (so library users
 # get more debug hints), but still attempt to load the file.

--- a/neverwinter/key.nim
+++ b/neverwinter/key.nim
@@ -1,7 +1,7 @@
-import streams, sequtils, strutils, tables, times, os, sets, math, checksums/sha1, std/oids
+import streams, sequtils, strutils, tables, times, os, sets, math, std/oids
 doAssert(($genOid()).len == 24)
 
-import resman, util, compressedbuf, exo
+import resman, util, compressedbuf, exo, checksums
 
 # bif and key version NEEDS to match
 type KeyBifVersion* {.pure.} = enum

--- a/neverwinter/nwsync.nim
+++ b/neverwinter/nwsync.nim
@@ -2,7 +2,7 @@ import std/[streams, critbits, os, algorithm, strutils, sequtils, math, options]
 
 import neverwinter/restype, neverwinter/resref, neverwinter/streamext
 
-import checksums/sha1
+import checksums
 
 # Bit of a hack, sorry: always print securehash in lowercase
 proc `$`*(s: SecureHash): string =

--- a/neverwinter/resman.nim
+++ b/neverwinter/resman.nim
@@ -16,10 +16,10 @@
 ## inherits from ResConainer and then creating the required methods (see below).
 
 
-import options, streams, sets, times, strutils, checksums/sha1
+import options, streams, sets, times, strutils
 export options, streams, sets
 
-import resref, restype, util, lru, exo, compressedbuf
+import resref, restype, util, lru, exo, compressedbuf, checksums
 export resref, restype
 
 const MemoryCacheThreshold* = 1024 * 1024 # 1MB

--- a/neverwinter/resnwsync.nim
+++ b/neverwinter/resnwsync.nim
@@ -1,12 +1,12 @@
 import std/streams, std/tables, std/os, std/sequtils, std/strutils, std/times, std/logging,
-  checksums/sha1, std/hashes
+  std/hashes
 
 when NimMajor == 2:
   import db_connector/db_sqlite
 else:
   import std/db_sqlite
 
-import resman, compressedbuf
+import resman, compressedbuf, checksums
 
 const NWSyncCompressedBufMagicStr* = "NSYC"
 const NWSyncCompressedBufMagic* = makeMagic(NWSyncCompressedBufMagicStr)

--- a/nwn_erf.nim
+++ b/nwn_erf.nim
@@ -1,4 +1,4 @@
-import shared, checksums/sha1, std/oids
+import shared, checksums, std/oids
 
 let args = DOC """
 Un/packs erf files.

--- a/nwn_erf_tlkify.nim
+++ b/nwn_erf_tlkify.nim
@@ -1,4 +1,4 @@
-import shared, checksums/sha1, std/oids
+import shared, checksums, std/oids
 
 import critbits, os, tables, options, sets, sequtils, strutils, logging
 

--- a/nwn_key_pack.nim
+++ b/nwn_key_pack.nim
@@ -1,4 +1,4 @@
-import shared, checksums/sha1
+import shared, checksums
 
 let args = DOC """
 This utility packs a .key file and all associated bifs from directory tree.

--- a/nwn_resman_grep.nim
+++ b/nwn_resman_grep.nim
@@ -1,4 +1,4 @@
-import shared, checksums/sha1, checksums/md5
+import shared, checksums
 
 let args = DOC """
 Find files in resman

--- a/nwn_resman_pkg.nim
+++ b/nwn_resman_pkg.nim
@@ -1,4 +1,4 @@
-import shared, checksums/sha1
+import shared, checksums
 
 const ServerPackageExtensions = [
   # walkmeshes: needed to pathfind

--- a/private/checksums.nim
+++ b/private/checksums.nim
@@ -1,0 +1,6 @@
+when NimMajor == 2:
+  import checksums/[sha1, md5]
+else:
+  import std/[sha1, md5]
+
+export sha1, md5


### PR DESCRIPTION
The checksums package now requires Nim 2, preventing compilation of neverwinter.nim on 1.6.x. This change makes older versions of Nim use the original std/sha1 and std/md5 modules instead of those provided by checksums.

## Testing

Compiles with Nim 1.6.14 and Nim 2.0.2.

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
