### PR TITLE
scriptcomp: fix Unidentified Identifier errors not displaying the identifier name

### DIFF
--- a/neverwinter/nwscript/native/scriptcompfinalcode.cpp
+++ b/neverwinter/nwscript/native/scriptcompfinalcode.cpp
@@ -763,7 +763,6 @@ int32_t CScriptCompiler::OutputIdentifierError(const CExoString &sFunctionName, 
 int32_t CScriptCompiler::ResolveLabels()
 {
 
-	CExoString sFunctionName;
 	BOOL bFoundLabel;
 	BOOL bFoundIdentifier;
 
@@ -886,7 +885,7 @@ int32_t CScriptCompiler::ResolveLabels()
 					return OutputWalkTreeError(STRREF_CSCRIPTCOMPILER_ERROR_UNKNOWN_STATE_IN_COMPILER, NULL);
 				}
 
-				return OutputIdentifierError(sFunctionName,STRREF_CSCRIPTCOMPILER_ERROR_UNDEFINED_IDENTIFIER,0);
+				return OutputIdentifierError(sNewFunctionName,STRREF_CSCRIPTCOMPILER_ERROR_UNDEFINED_IDENTIFIER,0);
 			}
 		}
 	}


### PR DESCRIPTION
`CExoString sFunctionName;` was only ever declared and never assigned.

## Testing

It worked in the game. Haven't compiled/tested the standalone compiler.

## Changelog

### Fixed

- scriptcomp: fixed Unidentified Identifier errors not displaying the identifier name.

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
