### PR TITLE
scriptcomp: Use explicit CExoString::ToString() instead of implicit ctor from int

### DIFF
--- a/neverwinter/nwscript/native/exobase.h
+++ b/neverwinter/nwscript/native/exobase.h
@@ -130,12 +130,7 @@ public:
 	//          of a CExoString.
 	///////////////////////////////////////////////////////////////////////////
 
-	///////////////////////////////////////////////////////////////////////////
-	CExoString(int32_t value);
-	//-------------------------------------------------------------------------
-	// Desc:    Creates a CExoString representing the int value.
-	///////////////////////////////////////////////////////////////////////////
-
+    static CExoString ToString(int32_t value);
 
     // The most rudimentary of std::string interop.
     CExoString(const std::string& other);

--- a/neverwinter/nwscript/native/exostring.cpp
+++ b/neverwinter/nwscript/native/exostring.cpp
@@ -138,18 +138,12 @@ CExoString::CExoString(const char *source, int32_t length)
 }
 
 // Creates a CExoString representing the int value
-CExoString::CExoString(int32_t value)
+CExoString CExoString::ToString(int32_t value)
 {
-	char buffer[33];
-
-	sprintf( buffer, "%i", value );
-
-    m_nBufferLength = (uint32_t)strlen(buffer) + 1;
-	m_sString = new char[m_nBufferLength];
-	strcpy(m_sString, buffer);
-
+    char buffer[33];
+    sprintf( buffer, "%i", value );
+    return CExoString(buffer);
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////
 //  CExoString::~CExoString()

--- a/neverwinter/nwscript/native/scriptcompcore.cpp
+++ b/neverwinter/nwscript/native/scriptcompcore.cpp
@@ -1507,7 +1507,7 @@ int32_t CScriptCompiler::OutputError(int32_t nError, CExoString *psFileName, int
         sTraceIncludes = sTraceIncludes + " " + m_pcIncludeFileStack[i].m_sCompiledScriptName + ".nss";
 
         if (m_pcIncludeFileStack[i].m_nLine > 0)
-            sTraceIncludes = sTraceIncludes + "(" + m_pcIncludeFileStack[i].m_nLine + ")";
+            sTraceIncludes = sTraceIncludes + "(" + CExoString::ToString(m_pcIncludeFileStack[i].m_nLine) + ")";
     }
 
     if (!sTraceIncludes.IsEmpty())


### PR DESCRIPTION
The implicit ctor was a mistake that's gone from the game.

## Testing

It compiles.

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
