### PR TITLE
Add graphviz output for the parse tree

### DIFF
--- a/neverwinter/nwscript/compiler.nim
+++ b/neverwinter/nwscript/compiler.nim
@@ -169,7 +169,8 @@ proc scriptCompApiNewCompiler(
   resolver: ResManLoadScriptSourceFile,
   tlk: TlkResolve = resolveTlk,
   writeDebug: bool,
-  maxIncludeDepth: cint
+  maxIncludeDepth: cint,
+  graphvizOut: cstring
 ): CScriptCompiler {.importc.}
 
 proc scriptCompApiCompileFile(instance: CScriptCompiler, fn: cstring): tuple[code: int32, str: cstring] {.importc.}
@@ -228,7 +229,8 @@ proc newCompiler*(
     lang: LangSpec,
     writeDebug: bool,
     resolver: Resolver,
-    maxIncludeDepth: int = 16
+    maxIncludeDepth: int = 16,
+    graphvizOut: string = ""
 ): ScriptCompiler =
   ## Instance a new compiler, which will read data by calling resolver.
   ## Any compilation results are returned by the respective functions.
@@ -246,14 +248,16 @@ proc newCompiler*(
     resolveFileInMem,
     resolveTlk,
     writeDebug,
-    maxIncludeDepth.cint
+    maxIncludeDepth.cint,
+    graphvizOut.cstring
   )
 
 proc newCompiler*(
     lang: LangSpec,
     writeDebug: bool,
     resman: ResMan,
-    maxIncludeDepth: int = 16
+    maxIncludeDepth: int = 16,
+    graphvizOut: string = ""
 ): ScriptCompiler =
   ## Instance a new compiler, which will read data from the ResMan you give it.
   ## Any compilation results are returned by the respective functions.
@@ -271,7 +275,8 @@ proc newCompiler*(
     resolveFileResMan,
     resolveTlk,
     writeDebug,
-    maxIncludeDepth.cint
+    maxIncludeDepth.cint,
+    graphvizOut.cstring
   )
 
 proc compileFile*(instance: ScriptCompiler, fn: string): CompileResult =

--- a/neverwinter/nwscript/compilerapi.cpp
+++ b/neverwinter/nwscript/compilerapi.cpp
@@ -7,7 +7,8 @@ extern "C" CScriptCompiler* scriptCompApiNewCompiler(
     const char* (*ResManLoadScriptSourceFile)(const char* fn, RESTYPE rt),
     const char* (*TlkResolve)(STRREF strRef),
     bool writeDebug,
-    int maxIncludeDepth
+    int maxIncludeDepth,
+    const char *graphvizOut
 )
 {
     CScriptCompilerAPI api;
@@ -22,6 +23,7 @@ extern "C" CScriptCompiler* scriptCompApiNewCompiler(
     instance->SetIdentifierSpecification(lang);
     instance->SetOutputAlias("scriptout");
     instance->SetMaxIncludeDepth(maxIncludeDepth);
+    instance->SetGraphvizOutputPath(graphvizOut);
     return instance;
 }
 

--- a/neverwinter/nwscript/native/scriptcomp.h
+++ b/neverwinter/nwscript/native/scriptcomp.h
@@ -306,6 +306,10 @@ public:
 	int32_t WriteFinalCodeToFile(const CExoString &sFileName);
 	int32_t WriteDebuggerOutputToFile(CExoString sFileName);
 
+	// This bypasses resman and the callback and writes to the file directly
+	// Only used by the external compiler if a debug option is passed in.
+	void SetGraphvizOutputPath(const CExoString& sPath) { m_sGraphvizPath = sPath; }
+
 	// *************************************************************************
 private:
 	// *************************************************************************
@@ -456,6 +460,7 @@ private:
 	BOOL m_bCompileConditionalOrMain;
 	CExoString m_sLanguageSource;
 	CExoString m_sOutputAlias;
+	CExoString m_sGraphvizPath;
 
 	int32_t m_nLines;
 	int32_t m_nCharacterOnLine;

--- a/neverwinter/nwscript/native/scriptcompfinalcode.cpp
+++ b/neverwinter/nwscript/native/scriptcompfinalcode.cpp
@@ -93,6 +93,42 @@ int32_t CScriptCompiler::GenerateFinalCodeFromParseTree(CExoString sFileName)
 		OutputWalkTreeError(nReturnValue, NULL);
 	}
 
+	if (!m_sGraphvizPath.IsEmpty())
+	{
+		CExoString sDotFile = m_sGraphvizPath + "/" + sFileName + ".dot";
+		FILE *f = fopen(sDotFile.CStr(), "w");
+		if (f)
+		{
+			fprintf(f, "digraph parsetree_%s {\n", sFileName.CStr());
+			fprintf(f, "graph [\n"
+						"    label=\"ParseTree for %s.nss\\n\\n\"\n"
+						"    labelloc=t\n"
+						"    layout=dot\n"
+						"    fontsize=40\n"
+						"];\n", sFileName.CStr());
+			fprintf(f, "node [shape=record];\n");
+
+			std::vector<CScriptParseTreeNode*> nodes;
+			CScriptParseTreeNode *pNode = pNewReturnTree;
+			while (pNode)
+			{
+				pNode->GraphvizDump(f);
+				fflush(f);
+				if (pNode->pLeft)
+					nodes.push_back(pNode->pLeft);
+				if (pNode->pRight)
+					nodes.push_back(pNode->pRight);
+
+				if (nodes.empty())
+					break;
+				pNode = nodes.back();
+				nodes.pop_back();
+			}
+			fprintf(f, "}\n");
+			fclose(f);
+		}
+	}
+
 	if (nReturnValue < 0)
 	{
 		return CleanUpAfterCompile(nReturnValue,pNewReturnTree);

--- a/neverwinter/nwscript/native/scriptinternal.h
+++ b/neverwinter/nwscript/native/scriptinternal.h
@@ -563,6 +563,51 @@ public:
         fprintf(out, "  TypeName:          \"%s\"\n", m_psTypeName ? m_psTypeName->CStr() : "");
         fprintf(out, "  File/Line/Char/SP: %d %d %d %d\n", m_nFileReference, nLine, nChar, m_nStackPointer);
     }
+    void GraphvizDump(FILE *fp)
+    {
+        // Try to keep the noise to a minimum since the graph can have millions of nodes
+        fprintf(fp, "node%p [label=\"%s\\n", this, OperationToString(nOperation));
+        if (nType != CSCRIPTCOMPILER_TOKEN_UNKNOWN)
+            fprintf(fp, "%s\\n", TokenKeywordToString(nType));
+
+        if (m_psStringData && !m_psStringData->IsEmpty())
+        {
+            CExoString sanitized = m_psStringData->RemoveAll("\"\n\\<>|");
+            if (sanitized.IsEmpty())
+                sanitized = "?";
+            fprintf(fp, "STR: '%s'\\n", sanitized.CStr());
+        }
+
+        if (m_psTypeName && !m_psTypeName->IsEmpty())
+            fprintf(fp, "TYP: '%s'\\n", m_psTypeName->CStr());
+
+        if (nIntegerData2 || nIntegerData3 || nIntegerData4)
+        {
+            fprintf(fp, "INT: %d %d %d %d\\n", nIntegerData, nIntegerData2, nIntegerData3, nIntegerData4);
+        }
+        else if (nIntegerData)
+        {
+            fprintf(fp, "INT: %d\\n", nIntegerData);
+        }
+
+        if (fVectorData[0] || fVectorData[1] || fVectorData[2])
+        {
+            fprintf(fp, "FLT: %f %f %f %f\\n", fFloatData, fVectorData[0], fVectorData[1], fVectorData[2]);
+        }
+        else if (fFloatData)
+        {
+            fprintf(fp, "FLT: %f\\n", fFloatData);
+        }
+
+        if (m_nStackPointer)
+            fprintf(fp, "SP: %d\\n", m_nStackPointer);
+
+        fprintf(fp, "Loc: %d:%d:%d\\n", m_nFileReference, nLine, nChar);
+        fprintf(fp, "\"];\n"); // end nodeXXX [labe="..."];
+
+        if (pLeft)  fprintf(fp, "node%p -> node%p [color=green];\n", this, pLeft);
+        if (pRight) fprintf(fp, "node%p -> node%p [color=red];\n", this, pRight);
+    }
 };
 
 #define CSCRIPTCOMPILER_PARSETREENODEBLOCK_SIZE 4096

--- a/nwn_script_comp.nim
+++ b/nwn_script_comp.nim
@@ -46,6 +46,8 @@ Usage:
   --restype-src TYPE          ResType to use for source lookup [default: nss]
   --restype-bin TYPE          ResType to use for binary output [default: ncs]
   --restype-dbg TYPE          ResType to use for debug output [default: ndb]
+
+  --graphviz DIR              Dump the parse tree as graphviz DOT to DIR.
 $OPTRESMAN
 """
 
@@ -61,6 +63,7 @@ type
     outDirectory: string
     maxIncludeDepth: 1..200
     followSymlinks: bool
+    graphvizOut: string
 
   GlobalState = object
     successes, errors, skips: Atomic[uint]
@@ -103,6 +106,7 @@ globalState.params = Params(
   outDirectory: if globalState.args["-d"]: ($globalState.args["-d"]) else: "",
   maxIncludeDepth: parseInt($globalState.args["--max-include-depth"]),
   followSymlinks: globalState.args["--follow-symlinks"],
+  graphvizOut: if globalState.args["--graphviz"]: ($globalState.args["--graphviz"]) else: "",
 )
 
 if globalState.params.outDirectory != "" and not dirExists(globalState.params.outDirectory):
@@ -192,7 +196,7 @@ proc getThreadState(): ThreadState {.gcsafe.} =
     #       will depend on logging and related to be set up.
     discard DOC(ArgsHelp, false)
     state.chDemandResRefResponse.open(maxItems=1)
-    state.cNSS = newCompiler(params.langSpec, params.debugSymbols, resolveFile, params.maxIncludeDepth)
+    state.cNSS = newCompiler(params.langSpec, params.debugSymbols, resolveFile, params.maxIncludeDepth, params.graphvizOut)
     state.cNSS.setOptimizations(params.optFlags)
   state
 


### PR DESCRIPTION
Adds a `--graphviz` argument to nwn_script_comp that allows dumping the final parse tree as graphviz DOT file.
This output bypasses the sandbox and the compiler will fopen() and write to the file directly. This makes it unsuitable for the game, but it should be fine for nwn_script_comp as it's only used when developing the compiler.

For example, this script:
```C
void main()
{
    string hello = "Hello, NWN\n";
    PrintString(hello);
}
```
generates the following DOT file:
```
digraph parsetree_test {
graph [
    label="ParseTree for test.nss\n\n"
    labelloc=t
    layout=dot
    fontsize=40
];
node [shape=record];
node0x7f5280175328 [label="FUNCTIONAL_UNIT\nLoc: 0:6:1\n"];
node0x7f5280175328 -> node0x7f5280175bb0 [color=green];
node0x7f5280175bb0 [label="FUNCTION\nLoc: 0:1:10\n"];
node0x7f5280175bb0 -> node0x7f5280175c18 [color=green];
node0x7f5280175bb0 -> node0x7f5280175390 [color=red];
node0x7f5280175390 [label="COMPOUND_STATEMENT\nLoc: 0:5:1\n"];
node0x7f5280175390 -> node0x7f52801753f8 [color=green];
node0x7f52801753f8 [label="STATEMENT_LIST\nLoc: 0:5:1\n"];
node0x7f52801753f8 -> node0x7f5280175b48 [color=green];
node0x7f5280175b48 [label="STATEMENT\nLoc: 0:3:11\n"];
node0x7f5280175b48 -> node0x7f52801759a8 [color=green];
node0x7f5280175b48 -> node0x7f5280175668 [color=red];
node0x7f5280175668 [label="STATEMENT\nSP: 1\nLoc: 0:4:16\n"];
node0x7f5280175668 -> node0x7f5280175598 [color=green];
node0x7f5280175598 [label="ACTION\nLoc: 0:4:16\n"];
node0x7f5280175598 -> node0x7f5280175460 [color=green];
node0x7f5280175598 -> node0x7f5280175600 [color=red];
node0x7f5280175600 [label="ACTION_ID\nSTR: 'PrintString'\nINT: 6274\nLoc: 0:4:16\n"];
node0x7f5280175460 [label="ACTION_ARG_LIST\nKEYWORD_STRING\nLoc: 0:4:22\n"];
node0x7f5280175460 -> node0x7f52801754c8 [color=red];
node0x7f52801754c8 [label="NON_VOID_EXPRESSION\nKEYWORD_STRING\nSP: 1\nLoc: 0:4:22\n"];
node0x7f52801754c8 -> node0x7f5280175530 [color=green];
node0x7f5280175530 [label="VARIABLE\nKEYWORD_STRING\nLoc: 0:4:22\n"];
node0x7f52801759a8 [label="STATEMENT_LIST\nLoc: 0:3:17\n"];
node0x7f52801759a8 -> node0x7f5280175a10 [color=green];
node0x7f5280175a10 [label="STATEMENT\nLoc: 0:3:17\n"];
node0x7f5280175a10 -> node0x7f5280175a78 [color=green];
node0x7f5280175a10 -> node0x7f52801757a0 [color=red];
node0x7f52801757a0 [label="STATEMENT\nINT: -4\nSP: 1\nLoc: 0:3:18\n"];
node0x7f52801757a0 -> node0x7f5280175808 [color=green];
node0x7f5280175808 [label="ASSIGNMENT\nKEYWORD_STRING\nLoc: 0:3:18\n"];
node0x7f5280175808 -> node0x7f52801756d0 [color=green];
node0x7f5280175808 -> node0x7f5280175870 [color=red];
node0x7f5280175870 [label="VARIABLE\nKEYWORD_STRING\nLoc: 0:3:18\n"];
node0x7f52801756d0 [label="NON_VOID_EXPRESSION\nKEYWORD_STRING\nSP: 1\nLoc: 0:3:34\n"];
node0x7f52801756d0 -> node0x7f5280175738 [color=green];
node0x7f5280175738 [label="CONSTANT_STRING\nKEYWORD_STRING\nSTR: 'Hello, NWN'\nLoc: 0:3:33\n"];
node0x7f5280175a78 [label="KEYWORD_DECLARATION\nLoc: 0:3:17\n"];
node0x7f5280175a78 -> node0x7f5280175ae0 [color=green];
node0x7f5280175a78 -> node0x7f52801758d8 [color=red];
node0x7f52801758d8 [label="VARIABLE_LIST\nLoc: 0:3:17\n"];
node0x7f52801758d8 -> node0x7f5280175940 [color=green];
node0x7f5280175940 [label="VARIABLE\nSTR: 'hello'\nLoc: 0:3:17\n"];
node0x7f5280175ae0 [label="KEYWORD_STRING\nLoc: 0:3:11\n"];
node0x7f5280175c18 [label="FUNCTION_DECLARATION\nLoc: 0:1:10\n"];
node0x7f5280175c18 -> node0x7f5280175c80 [color=green];
node0x7f5280175c80 [label="FUNCTION_IDENTIFIER\nSTR: 'main'\nLoc: 0:1:10\n"];
node0x7f5280175c80 -> node0x7f5280175ce8 [color=green];
node0x7f5280175ce8 [label="KEYWORD_VOID\nLoc: 0:1:5\n"];
}
```
which in turn can be converted to SVG with `dot -Tsvg test.dot > test.svg` and looks like:
![image](https://github.com/niv/neverwinter.nim/assets/7016472/1cb1493d-d0fc-4ea4-9e70-0122ef80d70c)

Alternatively, the DOT file can just be pasted to e.g. https://dreampuf.github.io/GraphvizOnline/ to see the graph.

No changelog entry, this is only useful for compiler developers.

## Testing

```
rm -f test.ncs test.dot test.svg && cat test.nss && bin/nwn_script_comp --graphviz . -O2 -g test.nss && bin/nwn_asm -d test.ncs && dot -Tsvg test.dot > test.svg && o test.svg
```

Tried with various script files, producing up to 18MBs chunky SVG files. The main failure mode seems to be string literals including special characters for DOT. I think I got them all.




## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
