### PR TITLE
Explicitly include <time.h> for __TIME__ and __DATE__ features

### DIFF
--- a/neverwinter/nwscript/native/scriptcompparsetree.cpp
+++ b/neverwinter/nwscript/native/scriptcompparsetree.cpp
@@ -48,6 +48,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 // external header files
 #include "exobase.h"


### PR DESCRIPTION
It gets implicitly picked up usually, but not always.

## Testing

None, but game needed this change to compile on Windows.

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
