### PR TITLE
Add hash string literal constants

### DIFF
--- a/neverwinter/nwscript/native/scriptcompcore.cpp
+++ b/neverwinter/nwscript/native/scriptcompcore.cpp
@@ -1849,11 +1849,13 @@ const char *TokenKeywordToString(int nTokenKeyword)
 		case CSCRIPTCOMPILER_TOKEN_KEYWORD_JSON_ARRAY:                        return "KEYWORD_JSON_ARRAY";
 		case CSCRIPTCOMPILER_TOKEN_KEYWORD_JSON_STRING:                       return "KEYWORD_JSON_STRING";
 		case CSCRIPTCOMPILER_TOKEN_KEYWORD_LOCATION_INVALID:                  return "KEYWORD_LOCATION_INVALID";
+		case CSCRIPTCOMPILER_TOKEN_RAW_STRING:                                return "RAW_STRING";
         case CSCRIPTCOMPILER_TOKEN_KEYWORD_DASHDASH_FUNCTION:                 return "KEYWORD_DASHDASH_FUNCTION";
         case CSCRIPTCOMPILER_TOKEN_KEYWORD_DASHDASH_FILE:                     return "KEYWORD_DASHDASH_FILE";
         case CSCRIPTCOMPILER_TOKEN_KEYWORD_DASHDASH_LINE:                     return "KEYWORD_DASHDASH_LINE";
         case CSCRIPTCOMPILER_TOKEN_KEYWORD_DASHDASH_DATE:                     return "KEYWORD_DASHDASH_DATE";
         case CSCRIPTCOMPILER_TOKEN_KEYWORD_DASHDASH_TIME:                     return "KEYWORD_DASHDASH_TIME";
+        case CSCRIPTCOMPILER_TOKEN_HASHED_STRING:                             return "HASHED_STRING";
 	}
 	return "(unknown token keyword)";
 }

--- a/neverwinter/nwscript/native/scriptinternal.h
+++ b/neverwinter/nwscript/native/scriptinternal.h
@@ -179,6 +179,7 @@
 #define CSCRIPTCOMPILER_TOKEN_KEYWORD_DASHDASH_LINE                   119
 #define CSCRIPTCOMPILER_TOKEN_KEYWORD_DASHDASH_DATE                   120
 #define CSCRIPTCOMPILER_TOKEN_KEYWORD_DASHDASH_TIME                   121
+#define CSCRIPTCOMPILER_TOKEN_HASHED_STRING                           122
 
 const char *TokenKeywordToString(int nTokenKeyword);
 

--- a/tests/scriptcomp/corpus/constants.nss
+++ b/tests/scriptcomp/corpus/constants.nss
@@ -90,6 +90,14 @@ BBB
 CCC";
 const string RAW_STRING_QUOTE = r"_""_";
 
+// Hashed strings
+const int HASHED_STRING_HELLO_LOWERCASE = h"hello";
+const int HASHED_STRING_HELLO_UPPERCASE = H"hello";
+const int HASHED_STRING_ZERO = h"";
+const int HASHED_STRING_CONSTANT_FOLD = h"AAA" + H"BBB";
+const int HASHED_STRING_SPECIAL_CHARACTERS = h"\"\n\\\xFF\x80";
+
+
 void main() 
 {
     // Test float literals
@@ -133,6 +141,13 @@ void main()
     Assert(RAW_STRING_SIMPLE_LOWERCASE != "Neverwinter\nNights");
     Assert(RAW_STRING_MULTILINE == "AAA\nBBB\nCCC");
     Assert(RAW_STRING_QUOTE == "_\"_");
+
+    Assert(HASHED_STRING_ZERO == 0);
+    Assert(HASHED_STRING_HELLO_LOWERCASE == HASHED_STRING_HELLO_UPPERCASE);
+    Assert(HASHED_STRING_CONSTANT_FOLD != 0);
+    Assert(HASHED_STRING_HELLO_LOWERCASE == -104060164); // HashString("hello") ingame
+    Assert(HASHED_STRING_SPECIAL_CHARACTERS != 0);
+
 
     // non-const strings can be larger than 32k
     string S64k = S16K + S16K + S16K + S16K;


### PR DESCRIPTION
`int n = h"hello";` is a compile time equivalent of `int n = HashString("hello");`. As with raw strings, both h"" and H"" are accepted.

Similar to raw strings, it works as a hack on the lexer. The string is parsed like a regular string would be and then when the end is found, the whole token gets replaced with 0x12345678 hex integer token containing the hash value. Then, the parser just sees an integer instead.

What this doesn't allow for is hashing non-literal constants at compile time, like:
```c
const string S = "foo";
const int H = h(S);
```
That would require an _operator_ and then constant folding. I was thinking of overloading unary `~` for strings to do this, but it would require VM changes as well.

## Testing

Added test case to constants.nss

## Changelog

### Added
- scriptcomp: Added support for hashed string literals, `h"..."` and `H"..."`.

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
