### PR TITLE
Optimize away dead branches when the IF condition is a constant

### DIFF
--- a/neverwinter/nwscript/compiler.nim
+++ b/neverwinter/nwscript/compiler.nim
@@ -46,6 +46,7 @@ type
     RemoveDeadCode       = 0x1
     FoldConstants        = 0x2
     MeldInstructions     = 0x4
+    RemoveDeadBranches   = 0x8
 
 const
   OptimizationFlagsO0* = {}

--- a/neverwinter/nwscript/native/scriptcomp.h
+++ b/neverwinter/nwscript/native/scriptcomp.h
@@ -56,6 +56,8 @@ class CScriptCompilerIdentifierHashTableEntry;
 #define CSCRIPTCOMPILER_OPTIMIZE_FOLD_CONSTANTS                       0x00000002
 // Post processes generated instructions to merge sequences into shorter equivalents
 #define CSCRIPTCOMPILER_OPTIMIZE_MELD_INSTRUCTIONS                    0x00000004
+// Removes the jump and the dead branches in if (CONST) constructs
+#define CSCRIPTCOMPILER_OPTIMIZE_DEAD_BRANCHES                        0x00000008
 
 #define CSCRIPTCOMPILER_OPTIMIZE_NOTHING                              0x00000000
 #define CSCRIPTCOMPILER_OPTIMIZE_EVERYTHING                           0xFFFFFFFF
@@ -535,6 +537,8 @@ private:
 	int32_t AddToGlobalVariableList(CScriptParseTreeNode *pGlobalVariableNode);
 
 	BOOL ConstantFoldNode(CScriptParseTreeNode *pNode, BOOL bForce=FALSE);
+
+	CScriptParseTreeNode *TrimParseTree(CScriptParseTreeNode *pNode);
 
 	BOOL m_bConstantVariableDefinition;
 

--- a/tests/scriptcomp/corpus/dead_branches.nss
+++ b/tests/scriptcomp/corpus/dead_branches.nss
@@ -1,0 +1,39 @@
+void main()
+{
+    // These should be dead-code-optimized so that the results are just:
+    //     CONST.I 1
+    //     ACTION Assert
+    // for the true cases and nothing for the false ones
+    if (0) Assert(FALSE);
+    if (1) Assert(TRUE);
+
+    if (1) Assert(TRUE);
+    else   Assert(FALSE);
+
+    if (0) Assert(FALSE);
+    else   Assert(TRUE);
+
+    // With constant folding
+    if (!0) Assert(TRUE);
+    if (!1) Assert(FALSE);
+    if (1+2+3) Assert(TRUE);
+    else Assert(FALSE);
+    if (1+2-3) Assert(FALSE);
+    else Assert(TRUE);
+    if (0 && 1) Assert(FALSE);
+    if (0 || 1) Assert(TRUE);
+
+    // These ones can't be dead-code-optimized
+    int zero = 0, one = 1;
+    if (zero) Assert(FALSE);
+    if (!zero) Assert(TRUE);
+    if (one) Assert(TRUE);
+    if (!one) Assert(FALSE);
+    if (zero+one) Assert(TRUE);
+
+    if (zero) Assert(FALSE);
+    else Assert(TRUE);
+
+    if (one) Assert(TRUE);
+    else Assert(FALSE);
+}


### PR DESCRIPTION
In a script like:
```c
void main() {
    if (1) {
        PrintString("THEN branch");
    } else {
        PrintString("ELSE branch");
    }
}
```
the generated code looks like:
```
void #loader():  [0:8]
  0   0   JSR      main                                      
  6   6   RET                                                

void main(): test.nss:1 [8:70]
  8   0   CONST.I  1              if (1) {                   
  14  6   JZ       46                                        
  20  12  CONST.S  "THEN branch"  PrintString("THEN branch");
  35  27  ACTION   PrintString                               
  40  32  JMP      68                                        
  46  38  NOP                     } else {                   
  48  40  CONST.S  "ELSE branch"  PrintString("ELSE branch");
  63  55  ACTION   PrintString                               
  68  60  RET                     }    
```
and the parse tree is:
![image](https://github.com/niv/neverwinter.nim/assets/7016472/2d34c4e9-910c-4d93-97fe-b56fe40b353b)

With this change, we detect this parse tree and trim it down to:
![image](https://github.com/niv/neverwinter.nim/assets/7016472/a18a89a6-80b8-45c0-989c-4274594a6d7e)

which results in the following NCS:
```
void #loader():  [0:8]
  0   0   JSR      main                                      
  6   6   RET                                                

void main(): test.nss:2 [8:30]
  8   0   CONST.S  "THEN branch"  PrintString("THEN branch");
  23  15  ACTION   PrintString                               
  28  20  RET                     }                
```

See comments in TrimParseTree() for details.

## Testing

- Added `dead_branches.nss` test case. Verified with `nwn_asm` that it removes dead branches, leaves ones that aren't entirely constant.
- @Finaldeath reported his AI scripts work as expected, NCS size went 514KB -> 301KB due to 240 `if (DEBUG)` dead statements
- @Daztek reported his codebase works as expected with the changes in place

## Changelog

### Performance Improvements
- scriptcomp: Will optimize away dead branches when an `if` condition is a constant

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
