### PR TITLE
nwn_script_comp: add further dead branch optimizations

### DIFF
--- a/neverwinter/nwscript/native/scriptcompcore.cpp
+++ b/neverwinter/nwscript/native/scriptcompcore.cpp
@@ -1596,9 +1596,22 @@ BOOL CScriptCompiler::ConstantFoldNode(CScriptParseTreeNode *pNode, BOOL bForce)
 		return FALSE;
 	}
 
-	// Only fold operations on same type. Expressions like "3.0f + 1" are not folded
+	// Only fold operations on same type. Expressions like "3.0f + 1" are not folded.
+    // With the exception of logical short circuit operations, that can be resolved
+    // from the left operand alone.
 	if (pNode->pRight && (pNode->pLeft->nOperation != pNode->pRight->nOperation))
-		return FALSE;
+    {
+        if (pNode->pLeft->nOperation != CSCRIPTCOMPILER_OPERATION_CONSTANT_INTEGER)
+            return FALSE;
+
+        if (pNode->nOperation != CSCRIPTCOMPILER_OPERATION_LOGICAL_OR &&
+            pNode->nOperation != CSCRIPTCOMPILER_OPERATION_LOGICAL_AND)
+            return FALSE;
+
+        if ((pNode->nOperation == CSCRIPTCOMPILER_OPERATION_LOGICAL_OR && !(pNode->pLeft->nIntegerData != 0)) ||
+            (pNode->nOperation == CSCRIPTCOMPILER_OPERATION_LOGICAL_AND && (pNode->pLeft->nIntegerData != 0)))
+		    return FALSE;
+    }
 
 	if (pNode->pLeft->nOperation == CSCRIPTCOMPILER_OPERATION_CONSTANT_INTEGER)
 	{

--- a/neverwinter/nwscript/native/scriptcompcore.cpp
+++ b/neverwinter/nwscript/native/scriptcompcore.cpp
@@ -1604,6 +1604,10 @@ BOOL CScriptCompiler::ConstantFoldNode(CScriptParseTreeNode *pNode, BOOL bForce)
         if (pNode->pLeft->nOperation != CSCRIPTCOMPILER_OPERATION_CONSTANT_INTEGER)
             return FALSE;
 
+        if (pNode->pRight->nOperation != CSCRIPTCOMPILER_OPERATION_CONSTANT_INTEGER &&
+            pNode->pRight->nOperation != CSCRIPTCOMPILER_OPERATION_INTEGER_EXPRESSION)
+            return FALSE;
+
         if (pNode->nOperation != CSCRIPTCOMPILER_OPERATION_LOGICAL_OR &&
             pNode->nOperation != CSCRIPTCOMPILER_OPERATION_LOGICAL_AND)
             return FALSE;


### PR DESCRIPTION
## Testing

Tested with 
void main()
```
{
    if (FALSE && GetIsObjectValid(GetModule()))
    {
        PrintString("1. 'if (FALSE && GetIsObjectValid(GetModule()))'. This is a dead branch.");
    }
    if (GetIsObjectValid(GetModule()) && FALSE)
    {
        PrintString("2. 'if (GetIsObjectValid(GetModule()) && FALSE)'. This is a live branch.");
    }
    if (FALSE || GetIsObjectValid(GetModule()))
    {
        PrintString("3. 'if (FALSE || GetIsObjectValid(GetModule()))'. This is a live branch.");
    }
    if (GetIsObjectValid(GetModule()) || FALSE)
    {
        PrintString("4. 'if (GetIsObjectValid(GetModule()) || FALSE)'. This is a live branch.");
    }
    if (TRUE && GetIsObjectValid(GetModule()))
    {
        PrintString("5. 'if (TRUE && GetIsObjectValid(GetModule()))'. This is a live branch.");
    }
    if (TRUE || GetIsObjectValid(GetModule()))
    {
        PrintString("6. 'if (TRUE || GetIsObjectValid(GetModule()))'. This is a live branch, but the second argument should be folded.");
    }
    if (TRUE || "some string")
    {
        PrintString("7. 'if (TRUE || \"some string\")'. This is a syntax error and shouldn't be folded.");
    }
    if (FALSE && "some string")
    {
        PrintString("8. 'if (FALSE && \"some string\")'. This is a syntax error and shouldn't be folded.");
    }
}
```
The code removes case 1 entirely, and removes the second argument from case 6. Cases 7 and 8 are skipped.

## Changelog

### Added
Checks to fold logical short circuit operations when possible.
EDIT: Made sure the right-side argument is an integer, to avoid folding cases that would later trigger a syntax error.

## Licence

* [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
