### PR TITLE
allow double bang (double boolean_not)

### DIFF
--- a/neverwinter/nwscript/native/scriptcompparsetree.cpp
+++ b/neverwinter/nwscript/native/scriptcompparsetree.cpp
@@ -798,6 +798,10 @@ int32_t CScriptCompiler::GenerateParseTree()
 					}
 					return 0;
 				}
+				else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_BOOLEAN_NOT)
+				{
+					PushSRStack(CSCRIPTCOMPILER_GRAMMAR_UNARY_EXPRESSION,0,0,NULL);
+				}
 				else
 				{
 					PARSER_ERROR(STRREF_CSCRIPTCOMPILER_ERROR_UNKNOWN_STATE_IN_COMPILER);

--- a/tests/scriptcomp/corpus/constants.nss
+++ b/tests/scriptcomp/corpus/constants.nss
@@ -128,7 +128,7 @@ void main()
     Assert(CONSTINT_DIVIDE == 0);
     Assert(CONSTINT_MODULUS == 10);
     Assert(CONSTINT_BOOLEAN_NOT == 0);
-    Assert(CONSTINT_BOOLEAN_NOT_NOT == 1)
+    Assert(CONSTINT_BOOLEAN_NOT_NOT == 1);
     Assert(CONSTINT_ONES_COMPLEMENT == -11);
     Assert(CONSTINT_NEGATION == -10);
 

--- a/tests/scriptcomp/corpus/constants.nss
+++ b/tests/scriptcomp/corpus/constants.nss
@@ -39,6 +39,7 @@ const int CONSTINT_MULTIPLY            = A *  B;
 const int CONSTINT_DIVIDE              = A /  B;
 const int CONSTINT_MODULUS             = A %  B;
 const int CONSTINT_BOOLEAN_NOT         = !A;
+const int CONSTINT_BOOLEAN_NOT_NOT     = !!A;
 const int CONSTINT_ONES_COMPLEMENT     = ~A;
 const int CONSTINT_NEGATION            = -A;
 
@@ -127,6 +128,7 @@ void main()
     Assert(CONSTINT_DIVIDE == 0);
     Assert(CONSTINT_MODULUS == 10);
     Assert(CONSTINT_BOOLEAN_NOT == 0);
+    Assert(CONSTINT_BOOLEAN_NOT_NOT == 1)
     Assert(CONSTINT_ONES_COMPLEMENT == -11);
     Assert(CONSTINT_NEGATION == -10);
 


### PR DESCRIPTION
Allows double boolean_not (`!!x`) without requiring the second booelan_not to be enclosed in parenthesis (i.e. `!(!x)`).

## Testing

Tested the following use cases:
- Single bang (boolean_not) -> `!x`
- Double bang -> `!!x`
- Parenthesized double bang -> `!(!x)`
- Multiple bangs -> `!!!x`
- Passed as a parameter -> `my_function(!!x)`

## Changelog

### Added
- Allow use of double-bang to "booleanize" a constant/variable integer value without requiring the second boolean negation to be parenthesized.

## Licence
- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
