### PR TITLE
scriptcomp: remove EXOASSERTNCSTR()

### DIFF
--- a/neverwinter/nwscript/native/exobase.h
+++ b/neverwinter/nwscript/native/exobase.h
@@ -57,8 +57,6 @@
 
 #include "exotypes.h"
 
-#define EXOASSERTNC() assert(false)
-#define EXOASSERTNCSTR(string) assert(!string)
 #define EXOASSERT(cond) assert(cond)
 #define EXOASSERTSTR(cond, string) assert(cond && string)
 

--- a/neverwinter/nwscript/native/scriptcompidentspec.cpp
+++ b/neverwinter/nwscript/native/scriptcompidentspec.cpp
@@ -676,7 +676,7 @@ int32_t CScriptCompiler::GenerateIdentifierList()
         else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_KEYWORD_JSON_STRING)
             m_pcIdentifierList[nLoc].m_psOptionalParameterStringData[nLoc2] = "\"\"";
         else
-            EXOASSERTNCSTR("missing impl");
+            assert(!"missing impl");
 
 		return 0;
     }

--- a/neverwinter/nwscript/native/scriptcompparsetree.cpp
+++ b/neverwinter/nwscript/native/scriptcompparsetree.cpp
@@ -616,7 +616,7 @@ int32_t CScriptCompiler::GenerateParseTree()
                     else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_KEYWORD_JSON_STRING)
                         pNewNode->m_psStringData = new CExoString("\"\"");
                     else
-                        EXOASSERTNCSTR("missing impl");
+                        assert(!"missing impl");
 
 					ModifySRStackReturnTree(pNewNode);
 					return 0;


### PR DESCRIPTION
These are already gone from the game.

## Testing
None.

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.