### PR TITLE
add support for binary (0b[0|1...]) and octal (0o[0-7...]) integers

### DIFF
--- a/neverwinter/nwscript/native/scriptcompcore.cpp
+++ b/neverwinter/nwscript/native/scriptcompcore.cpp
@@ -1873,6 +1873,8 @@ const char *TokenKeywordToString(int nTokenKeyword)
         case CSCRIPTCOMPILER_TOKEN_KEYWORD_DASHDASH_DATE:                     return "KEYWORD_DASHDASH_DATE";
         case CSCRIPTCOMPILER_TOKEN_KEYWORD_DASHDASH_TIME:                     return "KEYWORD_DASHDASH_TIME";
         case CSCRIPTCOMPILER_TOKEN_HASHED_STRING:                             return "HASHED_STRING";
+		case CSCRIPTCOMPILER_TOKEN_BINARY_INTEGER:                            return "BINARY_INTEGER";
+		case CSCRIPTCOMPILER_TOKEN_OCTAL_INTEGER:							  return "OCTAL_INTEGER";
 	}
 	return "(unknown token keyword)";
 }

--- a/neverwinter/nwscript/native/scriptcomplexical.cpp
+++ b/neverwinter/nwscript/native/scriptcomplexical.cpp
@@ -149,8 +149,7 @@ int32_t CScriptCompiler::ParseCharacterNumeric(int32_t ch)
 	{
 		m_pchToken[m_nTokenCharacters] = (char) ch;
 		++m_nTokenCharacters;
-		if (m_nTokenCharacters > CSCRIPTCOMPILER_MAX_TOKEN_LENGTH ||
-			m_nTokenCharacters > 33)
+		if (m_nTokenCharacters > CSCRIPTCOMPILER_MAX_TOKEN_LENGTH)
 		{
 			return STRREF_CSCRIPTCOMPILER_ERROR_TOKEN_TOO_LONG;
 		}
@@ -160,8 +159,7 @@ int32_t CScriptCompiler::ParseCharacterNumeric(int32_t ch)
 	{
 		m_pchToken[m_nTokenCharacters] = (char) ch;
 		++m_nTokenCharacters;
-		if (m_nTokenCharacters > CSCRIPTCOMPILER_MAX_TOKEN_LENGTH ||
-			m_nTokenCharacters > 13)
+		if (m_nTokenCharacters > CSCRIPTCOMPILER_MAX_TOKEN_LENGTH)
 		{
 			return STRREF_CSCRIPTCOMPILER_ERROR_TOKEN_TOO_LONG;
 		}
@@ -299,8 +297,7 @@ int32_t CScriptCompiler::ParseCharacterAlphabet(int32_t ch)
 			m_pchToken[m_nTokenCharacters] = (char) ch;
 		}
 		++m_nTokenCharacters;
-		if (m_nTokenCharacters >= CSCRIPTCOMPILER_MAX_TOKEN_LENGTH ||
-			m_nTokenCharacters > 10)
+		if (m_nTokenCharacters >= CSCRIPTCOMPILER_MAX_TOKEN_LENGTH)
 		{
 			return STRREF_CSCRIPTCOMPILER_ERROR_TOKEN_TOO_LONG;
 		}

--- a/neverwinter/nwscript/native/scriptcomplexical.cpp
+++ b/neverwinter/nwscript/native/scriptcomplexical.cpp
@@ -143,7 +143,28 @@ int32_t CScriptCompiler::ParseCharacterNumeric(int32_t ch)
 		{
 			return STRREF_CSCRIPTCOMPILER_ERROR_TOKEN_TOO_LONG;
 		}
-
+	}
+	else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_BINARY_INTEGER &&
+		(ch == '0' || ch == '1'))
+	{
+		m_pchToken[m_nTokenCharacters] = (char) ch;
+		++m_nTokenCharacters;
+		if (m_nTokenCharacters > CSCRIPTCOMPILER_MAX_TOKEN_LENGTH ||
+			m_nTokenCharacters > 33)
+		{
+			return STRREF_CSCRIPTCOMPILER_ERROR_TOKEN_TOO_LONG;
+		}
+	}
+	else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_OCTAL_INTEGER &&
+		(ch >= '0' && ch <= '7'))
+	{
+		m_pchToken[m_nTokenCharacters] = (char) ch;
+		++m_nTokenCharacters;
+		if (m_nTokenCharacters > CSCRIPTCOMPILER_MAX_TOKEN_LENGTH ||
+			m_nTokenCharacters > 13)
+		{
+			return STRREF_CSCRIPTCOMPILER_ERROR_TOKEN_TOO_LONG;
+		}
 	}
 	else
 	{
@@ -233,7 +254,7 @@ int32_t CScriptCompiler::ParseCharacterAlphabet(int32_t ch)
 	}
 
 	if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_INTEGER && (ch == 'x' || ch == 'X') &&
-	        m_nTokenCharacters == 1 && m_pchToken[0] == '0')
+	    m_nTokenCharacters == 1 && m_pchToken[0] == '0')
 	{
 		m_nTokenStatus = CSCRIPTCOMPILER_TOKEN_HEX_INTEGER;
 		m_pchToken[m_nTokenCharacters] = (char) ch;
@@ -242,7 +263,28 @@ int32_t CScriptCompiler::ParseCharacterAlphabet(int32_t ch)
 		{
 			return STRREF_CSCRIPTCOMPILER_ERROR_TOKEN_TOO_LONG;
 		}
-
+	}
+	else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_INTEGER && (ch == 'b' || ch == 'B') &&
+		m_nTokenCharacters == 1 && m_pchToken[0] == '0')
+	{
+		m_nTokenStatus = CSCRIPTCOMPILER_TOKEN_BINARY_INTEGER;
+		m_pchToken[m_nTokenCharacters] = (char) ch;
+		++m_nTokenCharacters;
+		if (m_nTokenCharacters >= CSCRIPTCOMPILER_MAX_TOKEN_LENGTH)
+		{
+			return STRREF_CSCRIPTCOMPILER_ERROR_TOKEN_TOO_LONG;
+		}
+	}
+	else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_INTEGER && (ch == 'o' || ch == 'O') &&
+		m_nTokenCharacters == 1 && m_pchToken[0] == '0')
+	{
+		m_nTokenStatus = CSCRIPTCOMPILER_TOKEN_OCTAL_INTEGER;
+		m_pchToken[m_nTokenCharacters] = (char) ch;
+		++m_nTokenCharacters;
+		if (m_nTokenCharacters >= CSCRIPTCOMPILER_MAX_TOKEN_LENGTH)
+		{
+			return STRREF_CSCRIPTCOMPILER_ERROR_TOKEN_TOO_LONG;
+		}
 	}
 	else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_HEX_INTEGER &&
 	         ((ch >= 'a' && ch <='f') ||
@@ -257,7 +299,8 @@ int32_t CScriptCompiler::ParseCharacterAlphabet(int32_t ch)
 			m_pchToken[m_nTokenCharacters] = (char) ch;
 		}
 		++m_nTokenCharacters;
-		if (m_nTokenCharacters >= CSCRIPTCOMPILER_MAX_TOKEN_LENGTH)
+		if (m_nTokenCharacters >= CSCRIPTCOMPILER_MAX_TOKEN_LENGTH ||
+			m_nTokenCharacters > 10)
 		{
 			return STRREF_CSCRIPTCOMPILER_ERROR_TOKEN_TOO_LONG;
 		}
@@ -1632,6 +1675,18 @@ int32_t CScriptCompiler::ParseNextCharacter(int32_t ch, int32_t chNext, const ch
 	{
 		return ParseCharacterAlphabet(ch);
 	}
+	else if ((ch == 'b' || ch == 'B') &&
+	         m_nTokenCharacters == 1 &&
+	         m_pchToken[0] == '0')
+	{
+		return ParseCharacterAlphabet(ch);
+	}
+	else if ((ch == 'o' || ch == 'O') &&
+	         m_nTokenCharacters == 1 &&
+	         m_pchToken[0] == '0')
+	{
+		return ParseCharacterAlphabet(ch);
+	}
 	else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_INTEGER || m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_FLOAT)
 	{
 		int32_t nCompiledCharacters = 0;
@@ -1672,6 +1727,22 @@ int32_t CScriptCompiler::ParseNextCharacter(int32_t ch, int32_t chNext, const ch
 		}
 	}
 	else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_HEX_INTEGER)
+	{
+		int nReturnValue = HandleToken();
+		if (nReturnValue < 0)
+		{
+			return nReturnValue;
+		}
+	}
+	else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_BINARY_INTEGER)
+	{
+		int nReturnValue = HandleToken();
+		if (nReturnValue < 0)
+		{
+			return nReturnValue;
+		}
+	}
+	else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_OCTAL_INTEGER)
 	{
 		int nReturnValue = HandleToken();
 		if (nReturnValue < 0)

--- a/neverwinter/nwscript/native/scriptcomplexical.cpp
+++ b/neverwinter/nwscript/native/scriptcomplexical.cpp
@@ -1726,23 +1726,9 @@ int32_t CScriptCompiler::ParseNextCharacter(int32_t ch, int32_t chNext, const ch
 			return nReturnValue;
 		}
 	}
-	else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_HEX_INTEGER)
-	{
-		int nReturnValue = HandleToken();
-		if (nReturnValue < 0)
-		{
-			return nReturnValue;
-		}
-	}
-	else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_BINARY_INTEGER)
-	{
-		int nReturnValue = HandleToken();
-		if (nReturnValue < 0)
-		{
-			return nReturnValue;
-		}
-	}
-	else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_OCTAL_INTEGER)
+	else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_HEX_INTEGER ||
+		m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_BINARY_INTEGER ||
+		m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_OCTAL_INTEGER)
 	{
 		int nReturnValue = HandleToken();
 		if (nReturnValue < 0)

--- a/neverwinter/nwscript/native/scriptcompparsetree.cpp
+++ b/neverwinter/nwscript/native/scriptcompparsetree.cpp
@@ -508,6 +508,32 @@ int32_t CScriptCompiler::GenerateParseTree()
 					ModifySRStackReturnTree(pNewNode);
 					return 0;
 				}
+				else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_BINARY_INTEGER)
+				{
+					CScriptParseTreeNode *pNewNode = CreateScriptParseTreeNode(CSCRIPTCOMPILER_OPERATION_CONSTANT_INTEGER,NULL,NULL);
+					m_pchToken[m_nTokenCharacters] = 0;
+					pNewNode->nIntegerData = 0;
+					for (nCount = 2; nCount < m_nTokenCharacters; nCount++)
+					{
+						pNewNode->nIntegerData *= 2;
+						pNewNode->nIntegerData += (m_pchToken[nCount] - '0');
+					}
+					ModifySRStackReturnTree(pNewNode);
+					return 0;
+				}
+				else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_OCTAL_INTEGER)
+				{
+					CScriptParseTreeNode *pNewNode = CreateScriptParseTreeNode(CSCRIPTCOMPILER_OPERATION_CONSTANT_INTEGER,NULL,NULL);
+					m_pchToken[m_nTokenCharacters] = 0;
+					pNewNode->nIntegerData = 0;
+					for (nCount = 2; nCount < m_nTokenCharacters; nCount++)
+					{
+						pNewNode->nIntegerData *= 8;
+						pNewNode->nIntegerData += (m_pchToken[nCount] - '0');
+					}
+					ModifySRStackReturnTree(pNewNode);
+					return 0;					
+				}
 				else if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_FLOAT)
 				{
 					CScriptParseTreeNode *pNewNode = CreateScriptParseTreeNode(CSCRIPTCOMPILER_OPERATION_CONSTANT_FLOAT,NULL,NULL);
@@ -736,6 +762,8 @@ int32_t CScriptCompiler::GenerateParseTree()
 			{
 				if (m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_INTEGER ||
 				        m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_HEX_INTEGER ||
+						m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_BINARY_INTEGER ||
+						m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_OCTAL_INTEGER ||
 				        m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_FLOAT ||
 				        m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_STRING ||
 				        m_nTokenStatus == CSCRIPTCOMPILER_TOKEN_KEYWORD_OBJECT_SELF ||

--- a/neverwinter/nwscript/native/scriptinternal.h
+++ b/neverwinter/nwscript/native/scriptinternal.h
@@ -180,6 +180,8 @@
 #define CSCRIPTCOMPILER_TOKEN_KEYWORD_DASHDASH_DATE                   120
 #define CSCRIPTCOMPILER_TOKEN_KEYWORD_DASHDASH_TIME                   121
 #define CSCRIPTCOMPILER_TOKEN_HASHED_STRING                           122
+#define CSCRIPTCOMPILER_TOKEN_BINARY_INTEGER                          123
+#define CSCRIPTCOMPILER_TOKEN_OCTAL_INTEGER                           124
 
 const char *TokenKeywordToString(int nTokenKeyword);
 

--- a/tests/scriptcomp/corpus/constants.nss
+++ b/tests/scriptcomp/corpus/constants.nss
@@ -1,5 +1,7 @@
 const int INT_LITERAL = 42;
-const int INT_HEX_LITERAL = 0x42;
+const int INT_HEX_LITERAL = 0x2A;
+const int INT_BINARY_LITERAL = 0b101010;
+const int INT_OCTAL_LITERAL = 0o052;
 const int INT_NEGATIVE_LITERAL = -42;
 
 const float FLOAT_LITERAL_FULL = 42.42f;


### PR DESCRIPTION
This PR is an answer to a question nobody asked and resolves no known problems.  This change allows the use of binary (`0[b|B]`) and octal (`0[o|O]`) integers in nwscript.  Additionally, it adds a check for the maximum length of the token based on type (8 characters after `0x` for hexadecimal, 31 characters after `0b` for binary, and 11 characters after `0o` for octal).

For the octal integers, I went with the `0o` prefix instead of the potentially more traditional numbers-that-begin-with-0 because numbers that begin with 0 are currently valid integers in nwscript and I wanted to ensure backward compatibility.

The whole token-length checking may be superfluous as normal integers are not checked.  Binary and Octal code has been kept in their own blocks instead of integrated into hex code blocks to make future modification or removal easier.

## Testing

Successfully tested against the following constructs:
`int h = [+-]0[xX][A-Fa-f0-9...]`
`int b = [+-]0[bB][01...]`
`int o = [+-]0[oO][0-7...]`

Example tests:
`my_function(h)`
`my_function(b + o)`
`int x = 0xff04ab + 0b000000100010001 + -0o03372`
`my_function(0xff04ab + 0b000000100010001 + -0o03372)`
`if(h)`
`if(0xff04ab)`
`while(b)`
`while(0xff04ab)`
`my_function(++a)`

Errors:
Compiler will error with `UNEXPECTED CHARACTER` if a hex number includes characters other than `[A-Fa-f0-9]`, a binary number includes characters other than `[01]`, or an octal number contains characters other than `[0-7]`.  The error `TOKEN TOO LONG` will be issued if a hex integer has more than 8 digits after `0x`, a binary integer has more than 31 characters after `0b`, or an octal integer has more than 11 characters after `0o`.

## Changelog

### Added
- Support for binary (prefix `0b`) and octal (prefix `0o`) integers.
- Check for character length after prefix for hexadecimal, binary and octal integers.

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
