### PR TITLE
Be tolerant of extensions that are in capitals

### DIFF
--- a/private/shared.nim
+++ b/private/shared.nim
@@ -138,7 +138,7 @@ proc ensureValidFormat*(format, filename: string,
   if result == "autodetect" and filename != "-":
     let ext = splitFile(filename).ext.strip(true, false, {'.'})
     for fmt, exts in supportedFormats:
-      if exts.contains(ext):
+      if exts.contains(ext.toLower):
         result = fmt
         break
 


### PR DESCRIPTION
This MR makes the tools accept files ending in capitals (eg: `.GIT`) and not only in lowercase.

This is needed only because the files in my toolsets temp0 folder are in capitals.

## Testing

Before:

```
$ nwn_gff -i /tmp/plc_bookpiles.UTP -o /tmp/plc_bookpiles.UTP.json
Cannot detect file format from filename: /tmp/plc_bookpiles.UTP
```

After:
```
ls /tmp/plc_bookpiles.UTP.json
# ls: cannot access '/tmp/plc_bookpiles.UTP.json': No such file or directory

nwn_gff -p -i /tmp/plc_bookpiles.UTP -o /tmp/plc_bookpiles.UTP.json

ls /tmp/plc_bookpiles.UTP.json
# /tmp/plc_bookpiles.UTP.json
```

## Changelog

### Changed

```
- lib: Now accepts file extensions in capital letters.
```

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licensed parts of the codebase.
