### PR TITLE
scriptcomp: disable for loop optimization

### DIFF
--- a/neverwinter/nwscript/native/scriptcompfinalcode.cpp
+++ b/neverwinter/nwscript/native/scriptcompfinalcode.cpp
@@ -7112,6 +7112,8 @@ void CScriptCompiler::EmitModifyStackPointer(int32_t nModifyBy)
 				return;
 			}
 		}
+		// Disabled for now, appears to cause infinite loops in some cases
+#if 0		
 		// The common loop pattern of `for (i = 0; i < 1000; ++i)` gets compiled into
 		//    10  CONSTANT, TYPE_INTEGER, 0               
 		//    16  RUNSTACK_COPY, TYPE_VOID, -4, 4         
@@ -7164,6 +7166,7 @@ void CScriptCompiler::EmitModifyStackPointer(int32_t nModifyBy)
 				}
 			}
 		}
+#endif
 
 	}
 


### PR DESCRIPTION
This optimization appears to cause issues with increment/decrement ops, like infinite loops. Disabling it for now.

Open issue: https://github.com/niv/neverwinter.nim/issues/141
Related PR: https://github.com/niv/neverwinter.nim/pull/86

## Testing

The script in the open issue mentioned above that hit the TMI limit due to an infinite loop now works correctly.

## Changelog

### Changed

- scriptcomp: disabled a for loop optimization where the compiler would sometimes generate code that caused an infinite loop.

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
