### PR TITLE
scriptcomp: enable easier language bindings

### DIFF
--- a/neverwinter/nwscript/compiler.nim
+++ b/neverwinter/nwscript/compiler.nim
@@ -28,8 +28,7 @@ type
     src, bin, dbg: ResType
 
   ResManWriteToFile = proc (fn: cstring, resType: uint16, pData: ptr uint8, size: csize_t, bin: bool): int32 {.cdecl.}
-  ResManLoadScriptSourceFile = proc (fn: cstring, resType: uint16): cstring {.cdecl.}
-  TlkResolve = proc (r: uint32): cstring {.cdecl.}
+  ResManLoadScriptSourceFile = proc (fn: cstring, resType: uint16): bool {.cdecl.}
 
   CompileResult* = tuple
     code: int32
@@ -50,16 +49,23 @@ const
   OptimizationFlagsO2* = fullSet(OptimizationFlag)
 
 proc scriptCompApiNewCompiler(
-  lang: cstring, src, bin, dbt: cint,
+  src, bin, dbt: cint,
   writer: ResManWriteToFile,
-  resolver: ResManLoadScriptSourceFile,
-  tlk: TlkResolve,
-  writeDebug: bool,
-  maxIncludeDepth: cint,
-  graphvizOut: cstring
+  resolver: ResManLoadScriptSourceFile
 ): CScriptCompiler {.importc.}
 
+proc scriptCompApiInitCompiler(
+  instance: CScriptCompiler,
+  lang: cstring,
+  writeDebug: bool,
+  maxIncludeDepth: cint,
+  graphvizOut: cstring,
+  outputAlias: cstring
+) {.importc.}
+
 proc scriptCompApiCompileFile(instance: CScriptCompiler, fn: cstring): tuple[code: int32, str: cstring] {.importc.}
+
+proc scriptCompApiDeliverFile(instance: CScriptCompiler, data: cstring, size: csize_t) {.importc.}
 
 # Since the C level API calls back for each invocation, we need to cache the
 # currently-calling compiler instance here. This makes all procs threadsafe, as long
@@ -81,9 +87,7 @@ proc writeFileInMem(fn: cstring, resType: uint16, pData: ptr uint8, size: csize_
     return 1
   return 0
 
-var resolveFileBuf {.threadvar.}: string
-
-proc resolveFileResMan(fn: cstring, ty: uint16): cstring {.cdecl.} =
+proc resolveFileResMan(fn: cstring, ty: uint16): bool {.cdecl.} =
   # Builtin callback that will invoke the provided resman instance in a thread and exception safe manner.
   # Not meant to be exposed to user code.
   assert not isNil currentCompilerInstance
@@ -91,25 +95,29 @@ proc resolveFileResMan(fn: cstring, ty: uint16): cstring {.cdecl.} =
     let r = newResRef($fn, ResType ty)
     let d = currentCompilerInstance.resman.demand(r)
     doAssert not isNil d, $r & " failed to resolve"
-    resolveFileBuf = d.readAll
-    if resolveFileBuf == "": return nil
-    return resolveFileBuf.cstring
+    let resolveFileBuf = d.readAll
+    if resolveFileBuf == "": return false
+    scriptCompApiDeliverFile(currentCompilerInstance.compiler,
+      resolveFileBuf.cstring, resolveFileBuf.len.csize_t)
+    return true
   except:
     # Must not throw back to C
     error "Failed to resolve ", $fn, ".", $ty, ":", getCurrentExceptionMsg()
-    return nil
+    return false
 
-proc resolveFileInMem(fn: cstring, ty: uint16): cstring {.cdecl.} =
+proc resolveFileInMem(fn: cstring, ty: uint16): bool {.cdecl.} =
   # Builtin callback that will invoke the provided resolver cb in a thread and exception safe manner.
   # Not meant to be exposed to user code.
   assert not isNil currentCompilerInstance
   try:
-    resolveFileBuf = currentCompilerInstance.resolver($fn, ResType ty)
-    return resolveFileBuf.cstring
+    let resolveFileBuf = currentCompilerInstance.resolver($fn, ResType ty)
+    scriptCompApiDeliverFile(currentCompilerInstance.compiler,
+      resolveFileBuf.cstring, resolveFileBuf.len.csize_t)
+    return true
   except:
     # Must not throw back to C
     error "Failed to resolve ", $fn, ".", $ty, ":", getCurrentExceptionMsg()
-    return nil
+    return false
 
 proc newCompiler*(
     lang: LangSpec,
@@ -129,13 +137,18 @@ proc newCompiler*(
   defer: currentCompilerInstance = nil
 
   result.compiler = scriptCompApiNewCompiler(
-    lang.lang.cstring, lang.src.cint, lang.bin.cint, lang.dbg.cint,
+    lang.src.cint, lang.bin.cint, lang.dbg.cint,
     writeFileInMem,
     resolveFileInMem,
-    nil,  # resolveTlk
+  )
+
+  scriptCompApiInitCompiler(
+    result.compiler,
+    lang.lang.cstring,
     writeDebug,
     maxIncludeDepth.cint,
-    graphvizOut.cstring
+    graphvizOut.cstring,
+    "scriptout"
   )
 
 proc newCompiler*(
@@ -156,13 +169,18 @@ proc newCompiler*(
   defer: currentCompilerInstance = nil
 
   result.compiler = scriptCompApiNewCompiler(
-    lang.lang.cstring, lang.src.cint, lang.bin.cint, lang.dbg.cint,
+    lang.src.cint, lang.bin.cint, lang.dbg.cint,
     writeFileInMem,
-    resolveFileResMan,
-    nil,  # resolveTlk
+    resolveFileResMan
+  )
+
+  scriptCompApiInitCompiler(
+    result.compiler,
+    lang.lang.cstring,
     writeDebug,
     maxIncludeDepth.cint,
-    graphvizOut.cstring
+    graphvizOut.cstring,
+    "scriptout"
   )
 
 proc compileFile*(instance: ScriptCompiler, fn: string): CompileResult =

--- a/neverwinter/nwscript/compilerapi.h
+++ b/neverwinter/nwscript/compilerapi.h
@@ -12,6 +12,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef _WIN32
+  #define EXPORT_SYMBOL __declspec(dllexport) extern "C"
+#else
+  #define EXPORT_SYMBOL extern "C"
+#endif
+
 typedef uint16_t RESTYPE;
 typedef uint32_t STRREF;
 
@@ -68,7 +74,7 @@ struct NativeCompileResult
 // Clients using this ABI must check the version before using it, and abort
 // if it is a mismatch.
 //
-extern "C" int32_t scriptCompApiGetABIVersion();
+EXPORT_SYMBOL int32_t scriptCompApiGetABIVersion();
 
 //
 // Create a new compiler instance.
@@ -76,7 +82,7 @@ extern "C" int32_t scriptCompApiGetABIVersion();
 // The compiler will use the given language specifier to load the identifier spec file
 // as the first request; if you fail to service it, you will likely crash.
 //
-extern "C" CScriptCompiler* scriptCompApiNewCompiler(int src, // 2009 = nss
+EXPORT_SYMBOL CScriptCompiler* scriptCompApiNewCompiler(int src, // 2009 = nss
     int bin,                                                  // 2010 = ncs
     int dbg,                                                  // 2064 = ndb
     ResManWriteToFile resManWriteToFile, ResManLoadScriptSourceFile resManLoadScriptSourceFile);
@@ -86,7 +92,7 @@ extern "C" CScriptCompiler* scriptCompApiNewCompiler(int src, // 2009 = nss
 // You MUST call this after NewCompiler. This is a separate step to allow
 // setting up callbacks and returning a instance.
 //
-extern "C" void scriptCompApiInitCompiler(CScriptCompiler* instance,
+EXPORT_SYMBOL void scriptCompApiInitCompiler(CScriptCompiler* instance,
     const char* lang,       // usually "nwscript"
     bool writeDebug = true, // Also emit NDB files
     int maxIncludeDepth = 16,
@@ -100,32 +106,36 @@ extern "C" void scriptCompApiInitCompiler(CScriptCompiler* instance,
 // If the script is not compilable, the callback will never be invoked; instead, you will
 // get a STRREF error code in the result.
 //
-extern "C" NativeCompileResult scriptCompApiCompileFile(CScriptCompiler* instance,
+EXPORT_SYMBOL NativeCompileResult scriptCompApiCompileFile(CScriptCompiler* instance,
     const char* filename);
 
 //
 // Deliver a requested file to the compiler. Behavior is undefined
 // outside of the ResManLoadScriptSourceFile callback.
 //
-extern "C" void scriptCompApiDeliverFile(CScriptCompiler* instance, const char* data, size_t size);
+EXPORT_SYMBOL void scriptCompApiDeliverFile(CScriptCompiler* instance, const char* data, size_t size);
 
 //
 // Get the current optimization flags.
 // This is a bitmask of CSCRIPTCOMPILER_OPTIMIZE_* values.
 // The default is CSCRIPTCOMPILER_OPTIMIZE_EVERYTHING.
 //
-extern "C" uint32_t scriptCompApiGetOptimizationFlags(CScriptCompiler* instance);
+EXPORT_SYMBOL uint32_t scriptCompApiGetOptimizationFlags(CScriptCompiler* instance);
 
 //
 // Set the optimization flags.
 // This allows you to toggle optimizations without re-creating the compiler.
 //
-extern "C" void scriptCompApiSetOptimizationFlags(CScriptCompiler* instance, uint32_t flags);
+EXPORT_SYMBOL void scriptCompApiSetOptimizationFlags(CScriptCompiler* instance, uint32_t flags);
 
 //
 // Set the compiler to generate debugger output.
 // This allows you to toggle the generation of NDB files without re-creating the compiler.
 //
-extern "C" void scriptCompApiSetGenerateDebuggerOutput(CScriptCompiler* instance, bool state);
+EXPORT_SYMBOL void scriptCompApiSetGenerateDebuggerOutput(CScriptCompiler* instance, bool state);
 
-extern "C" void scriptCompApiDestroyCompiler(CScriptCompiler* instance);
+//
+// Destroy the compiler instance. You should call this when you're done
+// using it to free allocated memory.
+//
+EXPORT_SYMBOL void scriptCompApiDestroyCompiler(CScriptCompiler* instance);

--- a/neverwinter/nwscript/compilerapi.h
+++ b/neverwinter/nwscript/compilerapi.h
@@ -1,0 +1,131 @@
+#pragma once
+
+//
+// To build the shared library on MacOS:
+//   g++ -O2 -fPIC -shared -std=c++14 \
+//     -o libnwnscriptcomp.dylib \
+//     neverwinter/nwscript/compilerapi.cpp \
+//     neverwinter/nwscript/native/*.{cpp,c}
+//
+
+#include <cstdint>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef uint16_t RESTYPE;
+typedef uint32_t STRREF;
+
+//
+// High level flow:
+// 1) Check ABI version (You must do this to ensure you're not loading a incompatible library)
+//    - scriptCompApiGetABIVersion
+// 2) Create a compiler instance, give it callbacks into your space.
+//    - scriptCompApiNewCompiler
+// 3) Call init, as that sets up the language spec.
+//    - scriptCompApiInitCompiler
+// 4) Compile one or more files. The files and all needed includes will be requested
+//    during this call (via the ResManLoadScriptSourceFile callback).
+//    After compilation, the compiler will call the ResManWriteToFile callback
+//    to write the compiled file and optionally the debug file.
+//    - scriptCompApiCompileFile
+// 5) Don't forget to destroy the compiler instance when you're done.
+//    - scriptCompApiDestroyCompiler
+//
+
+//
+// Called by the compiler when it wants to write a file.
+// Return 0 on success, or an error STRREF on failure.
+//
+typedef int32_t (*ResManWriteToFile)(const char* sFileName, RESTYPE nResType, const uint8_t* pData,
+    size_t nSize, bool bBinary);
+
+//
+// Called by the compiler when it wants the contents of a script file.
+//
+// Call Compiler->DeliverFile(...) to satisfy the request during the invocation
+// of this callback. The convoluted to/from is to work around managed memory
+// tracking issues on some languages.
+//
+// Return true if you serviced the request. Returning false indicates the
+// requested file does not exist; in which case you do not have to call
+// Compiler->DeliverFile(...).
+//
+typedef bool (*ResManLoadScriptSourceFile)(const char* fn, RESTYPE rt);
+
+class CScriptCompiler;
+
+struct NativeCompileResult
+{
+    // 0: OK, otherwise -(TLK) entry of error code.
+    int32_t code;
+    // This is a static buffer managed by the compiler.
+    const char* str;
+};
+
+//
+// Get the ABI version of the compiler API.
+// This is used to ensure that the compiler and the client are compatible.
+// Clients using this ABI must check the version before using it, and abort
+// if it is a mismatch.
+//
+extern "C" int32_t scriptCompApiGetABIVersion();
+
+//
+// Create a new compiler instance.
+//
+// The compiler will use the given language specifier to load the identifier spec file
+// as the first request; if you fail to service it, you will likely crash.
+//
+extern "C" CScriptCompiler* scriptCompApiNewCompiler(int src, // 2009 = nss
+    int bin,                                                  // 2010 = ncs
+    int dbg,                                                  // 2064 = ndb
+    ResManWriteToFile resManWriteToFile, ResManLoadScriptSourceFile resManLoadScriptSourceFile);
+
+//
+// Initialize the compiler instance.
+// You MUST call this after NewCompiler. This is a separate step to allow
+// setting up callbacks and returning a instance.
+//
+extern "C" void scriptCompApiInitCompiler(CScriptCompiler* instance,
+    const char* lang,       // usually "nwscript"
+    bool writeDebug = true, // Also emit NDB files
+    int maxIncludeDepth = 16,
+    // Graphviz output path (writes file directly, does not go trough ResManWriteToFile)
+    const char* graphvizOut = nullptr, const char* outputAlias = "scriptout");
+
+//
+// The compiler will use the given callbacks to load files and write output.
+// Upon completion of the compile, the compiler will call the write callback
+// to write the compiled file and optionally the debug file.
+// If the script is not compilable, the callback will never be invoked; instead, you will
+// get a STRREF error code in the result.
+//
+extern "C" NativeCompileResult scriptCompApiCompileFile(CScriptCompiler* instance,
+    const char* filename);
+
+//
+// Deliver a requested file to the compiler. Behavior is undefined
+// outside of the ResManLoadScriptSourceFile callback.
+//
+extern "C" void scriptCompApiDeliverFile(CScriptCompiler* instance, const char* data, size_t size);
+
+//
+// Get the current optimization flags.
+// This is a bitmask of CSCRIPTCOMPILER_OPTIMIZE_* values.
+// The default is CSCRIPTCOMPILER_OPTIMIZE_EVERYTHING.
+//
+extern "C" uint32_t scriptCompApiGetOptimizationFlags(CScriptCompiler* instance);
+
+//
+// Set the optimization flags.
+// This allows you to toggle optimizations without re-creating the compiler.
+//
+extern "C" void scriptCompApiSetOptimizationFlags(CScriptCompiler* instance, uint32_t flags);
+
+//
+// Set the compiler to generate debugger output.
+// This allows you to toggle the generation of NDB files without re-creating the compiler.
+//
+extern "C" void scriptCompApiSetGenerateDebuggerOutput(CScriptCompiler* instance, bool state);
+
+extern "C" void scriptCompApiDestroyCompiler(CScriptCompiler* instance);

--- a/neverwinter/nwscript/native/scriptcompcore.cpp
+++ b/neverwinter/nwscript/native/scriptcompcore.cpp
@@ -357,6 +357,10 @@ CScriptCompiler::CScriptCompiler(RESTYPE nSource, RESTYPE nCompiled, RESTYPE nDe
     m_nResTypeCompiled = nCompiled;
     m_nResTypeDebug = nDebug;
 
+    m_pDeliveredFileData = NULL;
+    m_nDeliveredFileDataSize = 0;
+    m_nDeliveredFileSize = 0;
+
 	Initialize();
 
 }
@@ -397,6 +401,8 @@ CScriptCompiler::~CScriptCompiler()
 			delete pCurrentPtr;
 		}
 	}
+
+	free(m_pDeliveredFileData);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1235,8 +1241,10 @@ int32_t CScriptCompiler::CompileFile(const CExoString &sFileName)
 
 	m_pcIncludeFileStack[m_nCompileFileLevel].m_sCompiledScriptName = sFileName;
 
-    const char* sTest = m_cAPI.ResManLoadScriptSourceFile(sFileName.CStr(), m_nResTypeSource);
-	if (!sTest)
+    m_nDeliveredFileSize = 0;
+
+    if (!m_cAPI.ResManLoadScriptSourceFile(sFileName.CStr(), m_nResTypeSource)
+        || m_nDeliveredFileSize == 0)
 	{
 		if (m_nCompileFileLevel > 0)
 		{
@@ -1245,7 +1253,10 @@ int32_t CScriptCompiler::CompileFile(const CExoString &sFileName)
 
 		return STRREF_CSCRIPTCOMPILER_ERROR_FILE_NOT_FOUND;
 	}
-    m_pcIncludeFileStack[m_nCompileFileLevel].m_sSourceScript = sTest;
+
+    const CExoString sCopy(m_pDeliveredFileData, m_nDeliveredFileSize);
+
+    m_pcIncludeFileStack[m_nCompileFileLevel].m_sSourceScript = sCopy;
     pScript = m_pcIncludeFileStack[m_nCompileFileLevel].m_sSourceScript.CStr();
     nScriptLength = m_pcIncludeFileStack[m_nCompileFileLevel].m_sSourceScript.GetLength();
 

--- a/neverwinter/nwscript/native/scriptcompidentspec.cpp
+++ b/neverwinter/nwscript/native/scriptcompidentspec.cpp
@@ -791,7 +791,7 @@ int32_t CScriptCompiler::GenerateIdentifierList()
 
 int32_t CScriptCompiler::PrintParseIdentifierFileError(int32_t nParsingError)
 {
-	CExoString strRes = m_cAPI.TlkResolve ? m_cAPI.TlkResolve(-nParsingError) : TlkToString(-nParsingError);
+    const CExoString strRes = TlkToString(-nParsingError);
 
 	CExoString *psFileName = &(m_pcIncludeFileStack[0].m_sCompiledScriptName);
 	OutputError(nParsingError,psFileName,m_nLines,strRes);
@@ -822,13 +822,17 @@ int32_t CScriptCompiler::ParseIdentifierFile()
 
 	m_nPredefinedIdentifierOrder = 0;
 
-    const char* sTest = m_cAPI.ResManLoadScriptSourceFile(m_sLanguageSource.CStr(), m_nResTypeSource);
-	if (!sTest)
+	m_nDeliveredFileSize = 0;
+
+    if (!m_cAPI.ResManLoadScriptSourceFile(m_sLanguageSource.CStr(), m_nResTypeSource)
+	    || m_nDeliveredFileSize == 0)
 	{
 		return PrintParseIdentifierFileError(STRREF_CSCRIPTCOMPILER_ERROR_FILE_NOT_FOUND);
 	}
 
-    m_pcIncludeFileStack[0].m_sSourceScript = sTest;
+    const CExoString sCopy(m_pDeliveredFileData, m_nDeliveredFileSize);
+
+    m_pcIncludeFileStack[0].m_sSourceScript = sCopy;
     pScript = m_pcIncludeFileStack[0].m_sSourceScript.CStr();
     nScriptLength = m_pcIncludeFileStack[0].m_sSourceScript.GetLength();
 

--- a/neverwinter/nwscript/py_ctypes_example.py
+++ b/neverwinter/nwscript/py_ctypes_example.py
@@ -1,0 +1,222 @@
+import ctypes
+from ctypes.util import find_library
+import timeit
+
+CB_WRITE = ctypes.CFUNCTYPE(
+    ctypes.c_int32,
+    ctypes.c_char_p,
+    ctypes.c_uint16,
+    ctypes.c_void_p,
+    ctypes.c_size_t,
+    ctypes.c_bool,
+)
+
+CB_LOAD = ctypes.CFUNCTYPE(
+    ctypes.c_char_p,
+    ctypes.c_char_p,
+    ctypes.c_uint16,
+)
+
+
+class NativeCompileResult(ctypes.Structure):
+    _fields_ = [
+        ("code", ctypes.c_int32),
+        ("str", ctypes.c_char_p),
+    ]
+
+
+lib = ctypes.cdll.LoadLibrary(find_library("nwnscriptcomp"))
+if lib is None:
+    raise ImportError("Could not load libscriptcomp")
+
+fn_abi = lib.scriptCompApiGetABIVersion
+fn_abi.argtypes = []
+fn_abi.restype = ctypes.c_int32
+
+fn_newcomp = lib.scriptCompApiNewCompiler
+fn_newcomp.argtypes = [
+    ctypes.c_int,  # src
+    ctypes.c_int,  # bin
+    ctypes.c_int,  # dbg
+    CB_WRITE,
+    CB_LOAD,
+]
+fn_newcomp.restype = ctypes.c_void_p
+
+fn_initcomp = lib.scriptCompApiInitCompiler
+fn_initcomp.argtypes = [
+    ctypes.c_void_p,  # compiler
+    ctypes.c_char_p,  # lang
+    ctypes.c_bool,  # writeDebug
+    ctypes.c_int,  # maxIncludeDepth
+    ctypes.c_char_p,  # graphvizOut
+    ctypes.c_char_p,  # outputAlias
+]
+
+fn_compile = lib.scriptCompApiCompileFile
+fn_compile.argtypes = [
+    ctypes.c_void_p,  # compiler
+    ctypes.c_char_p,  # filename
+]
+fn_compile.restype = NativeCompileResult
+
+fn_deliver_file = lib.scriptCompApiDeliverFile
+fn_deliver_file.argtypes = [
+    ctypes.c_void_p,  # compiler
+    ctypes.c_void_p,  # data
+    ctypes.c_size_t,  # size
+]
+
+fn_destroycomp = lib.scriptCompApiDestroyCompiler
+fn_destroycomp.argtypes = [
+    ctypes.c_void_p,  # compiler
+]
+
+
+class CompilationError(Exception):
+    """Exception raised for errors in the compilation process."""
+
+    def __init__(self, code: int, message: bytes):
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.str = b""
+
+    def __str__(self):
+        return f"CompilationError(code={self.code}, message={self.message})"
+
+
+class Compiler:
+    """
+    A class to compile NWScript using the NWScript compiler.
+
+    The compiler is encoding-agnostic and only deals with bytes; even
+    when requesting filenames.
+
+    Args:
+        resolver: A callable that resolves the filename and resource type.
+            It accepts two arguments: filename (bytes) and resource type (int).
+            It should return the file contents as bytes.
+    """
+
+    def __init__(
+        self,
+        resolver: callable,  # callable(filename: bytes, restype: int) -> bytes
+        src_rt=2009,  # nss
+        bin_rt=2010,  # ncs
+        dbg_rt=2064,  # ndb
+        langspec=b"nwscript",
+        max_include_depth=16,
+    ):
+        self._resolver = resolver
+        self._ncs = None
+        self._ndb = None
+
+        def cb_write(fn, rt, data, size, is_binary):
+            return self._write_file(fn, rt, data, size, is_binary)
+
+        def cb_load(fn, rt):
+            return self._load_file(fn, rt)
+
+        self.cb_write = CB_WRITE(cb_write)
+        self.cb_load = CB_LOAD(cb_load)
+        self.comp = fn_newcomp(src_rt, bin_rt, dbg_rt, self.cb_write, self.cb_load)
+
+        # NB: This will trigger the first request, for "nwscript.nss".
+        fn_initcomp(self.comp, langspec, True, max_include_depth, None, b"scriptout")
+
+    def __del__(self):
+        if self.comp:
+            fn_destroycomp(self.comp)
+            self.comp = None
+
+    def _write_file(self, fn, rt, data: bytes, size: int, is_binary: bool):
+        dat = bytes(ctypes.cast(data, ctypes.POINTER(ctypes.c_char * size)).contents)
+        if is_binary:
+            assert not self._ncs
+            self._ncs = dat
+        else:
+            assert not self._ndb
+            self._ndb = dat
+        return 0
+
+    def _load_file(self, fn, rt):
+        if data := self._resolver(fn, rt):
+            fn_deliver_file(self.comp, data, len(data))
+            return True
+
+        return False
+
+    def compile(self, filename: bytes) -> tuple[bytes, str]:
+        """
+        Compile the given script filename.
+
+        Args:
+            script: The script to compile. It will be requested
+                from the resolver.
+
+        Returns:
+            A tuple of (bytecode, debug data).
+
+        Raises:
+            CompilationError: If the compilation fails.
+        """
+        r = fn_compile(self.comp, filename)
+        if r.code != 0:
+            raise CompilationError(r.code, r.str)
+
+        assert self._ncs
+        assert self._ndb
+
+        ncs, ndb = self._ncs, self._ndb
+        self._ncs = None
+        self._ndb = None
+        return (ncs, ndb)
+
+
+test_files = {
+    b"nwscript": b"""
+int Nonsense(int n);
+    """,
+    b"incl": b"""
+int retval() { return Nonsense(42); }
+""",
+    b"test": b"""
+#include "incl"\n\nvoid main() {}
+""",
+}
+
+
+def main():
+    def resolver(filename: bytes, restype: int) -> bytes:
+        assert restype == 2009, f"unexpected restype: {restype=}"
+
+        if filename not in test_files:
+            print(f"not found: {filename=}")
+            return None
+
+        return test_files[filename]
+
+    comp = Compiler(resolver)
+
+    ret = comp.compile(b"test")
+    print(f"compilation result: {ret=}")
+
+    def _compile():
+        test = comp.compile(b"test")
+        # ncs build is currently expected to be reproducible
+        assert test[0] == ret[0]
+        assert test[1] == ret[1]
+
+    count = 10000
+    print(f"compiling {count}x")
+    bench = timeit.timeit("comp.compile(b'test')", number=count, globals=locals())
+    print(f"= {bench=}")
+
+    # Optional in production, but testing dtor code here.
+    del comp
+    print("done")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Change the scriptcomp API to deliver files not by callback, but instead by calling DeliverFile from
the callback. This is needed because managed memory languages cannot track dynamic buffers returned
from callbacks.

The API is now a real header you can include (or just implement in your FFI). A python example
is provided.

Supersedes #145.

## Testing

A test script is included; it works on my machine.

## Changelog

### Added

- scriptcomp: Support for better language bindings. Python example is included.

### Changed

- scriptcomp: ABI is now versioned; slight changes to support language bindings.

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
